### PR TITLE
asar 2.0 compatibility

### DIFF
--- a/all.asm
+++ b/all.asm
@@ -28,7 +28,7 @@ org $008000			;dummy org so functions work
 org $C00000
 	check bankcross half
 	incsrc "bank_C0.asm"
-	warnpc $C07FFC
+	assert pc() <= $C07FFC
 	padbyte $00
 	pad $C07FFC
 if !version == 1
@@ -39,7 +39,7 @@ endif
 
 ;weird copy of ship hold tilemap that fills the end of bank 80
 org $80F4B0
-	incbin "data/levels/32x32_tilemaps/ship_hold_32x32_tilemap.bin":0000-0AF6
+	incbin "data/levels/32x32_tilemaps/ship_hold_32x32_tilemap.bin":$0000..$0AF6
 
 ;some random looking bytes
 	db $56, $3F, $2C, $01, $05, $E3, $67, $AB
@@ -117,7 +117,7 @@ endif
 org $F90000
 	check bankcross full
 	incsrc "bank_F9.asm"
-	warnpc $F9D000
+	assert pc() <= $F9D000
 	padbyte $00
 	pad $F9D000
 org $B9D000
@@ -126,7 +126,7 @@ org $B9D000
 	pad $BA0000
 org $FA0000
 	incsrc "bank_FA.asm"
-	warnpc $FA9000
+	assert pc() <= $FA9000
 	padbyte $00
 	pad $FA9000
 org $BA9000
@@ -162,7 +162,7 @@ org $FD0000
 	pad $FE0000
 org $FE0000
 	incsrc "bank_FE.asm"
-	warnpc $FEB800
+	assert pc() <= $FEB800
 	padbyte $00
 	pad $FEB800
 org $BEB800

--- a/bank_80.asm
+++ b/bank_80.asm
@@ -1372,7 +1372,7 @@ CODE_808D8A:
 	ORA $08C2				;$808D8D   | set bit 12 (unclear yet, related to cutscenes)
 	STA $08C2				;$808D90   |
 	LDA $08A4				;$808D93   | get kong in front
-	JSL CODE_808837				;$808D96   | set kong 
+	JSL CODE_808837				;$808D96   | set kong
 	LDA #$0020				;$808D9A   |
 	ORA $30,x				;$808D9D   |
 	STA $30,x				;$808D9F   | set interaction flags
@@ -1385,9 +1385,9 @@ CODE_808D8A:
 	STX current_sprite			;$808DB2   |
 	LDA #$0004				;$808DB4   | load run animation
 	JSL CODE_B9D0B8				;$808DB7   | set kong animation
-	LDA.l DATA_FF012A			;$808DBB   | 
+	LDA.l DATA_FF012A			;$808DBB   |
 	STA $16E0				;$808DBF   | set dixie's gravity constant
-	LDA.l DATA_FF012C			;$808DC2   | 
+	LDA.l DATA_FF012C			;$808DC2   |
 	STA $16E2				;$808DC6   | set dixie's terminal velocity constant
 	LDX active_kong_sprite			;$808DC9   | get active kong
 	LDA #$001D				;$808DCC   |
@@ -1395,7 +1395,7 @@ CODE_808D8A:
 	LDA #$00E4				;$808DD1   |
 	STA $02,x				;$808DD4   | set render order
 	JSR CODE_808DFB				;$808DD6   | call dead code
-	LDX inactive_kong_sprite		;$808DD9   | get inactive kong 
+	LDX inactive_kong_sprite		;$808DD9   | get inactive kong
 	LDA #$001E				;$808DDC   |
 	STA $2E,x				;$808DDF   | set inactive kong to npc screen state
 	LDA #$00D8				;$808DE1   |
@@ -3166,7 +3166,7 @@ CODE_809DE2:
 	TAX					;$809DE7   |
 	LDA.l DATA_809C99,x			;$809DE8   |
 	STA $3A					;$809DEC   |
-	LDA #<:DATA_809C99			;$809DEE   |
+	LDA.w #<:DATA_809C99			;$809DEE   |
 	STA $3C					;$809DF1   |
 	LDY #$0000				;$809DF3   |
 	LDA #$0100				;$809DF6   |
@@ -3743,7 +3743,7 @@ CODE_80A440:					;	   |
 CODE_80A442:					;	   |
 	TXA					;$80A442   |
 	CLC					;$80A443   |
-	ADC #sizeof(sprite)			;$80A444   |
+	ADC.w #sizeof(sprite)			;$80A444   |
 	TAX					;$80A447   |
 	CPX #main_sprite_table_end		;$80A448   |
 	BNE CODE_80A429				;$80A44B   |
@@ -3786,7 +3786,7 @@ CODE_80A4A4:					;	   |
 	BEQ CODE_80A4B6				;$80A4A6   |
 	TXA					;$80A4A8   |
 	CLC					;$80A4A9   |
-	ADC #sizeof(sprite)			;$80A4AA   |
+	ADC.w #sizeof(sprite)			;$80A4AA   |
 	TAX					;$80A4AD   |
 	CPX #aux_sprite_table			;$80A4AE   |
 	BNE CODE_80A4A4				;$80A4B1   |
@@ -3981,11 +3981,11 @@ init_file_select:
 namespace run_file_select			;	   | Use this namespace to acces the sram_file_offsets
 	LDA.l sram_file_offsets,x		;$80A617   |\ Setup pointer to the active save file
 	STA .sram_pointer			;$80A61B   | |
-	LDA #<:sram_base			;$80A61D   | |
+	LDA.w #<:sram_base			;$80A61D   | |
 	STA .sram_pointer_bank			;$80A620   |/
 	%pea_use_dbr(sram_file_buffer)		;$80A622   |\ Swap out dbr to access full wram
 	PLB					;$80A625   |/
-	LDY #sizeof(save_file)-2		;$80A626   | Load file length
+	LDY.w #sizeof(save_file)-2		;$80A626   | Load file length
 	BRA .copy_sram				;$80A629  / Jump to the actual copy routine
 .unused						;	  \
 	LDA file_select_selection		;$80A62B   |\ Calculate the index to the current SRAM file
@@ -3995,19 +3995,19 @@ namespace run_file_select			;	   | Use this namespace to acces the sram_file_off
 	CLC					;$80A634   | |
 	ADC.w #save_file.contents		;$80A635   | | Skip the save file header
 	STA .sram_pointer			;$80A638   | |
-	LDA #<:sram_base			;$80A63A   | |
+	LDA.w #<:sram_base			;$80A63A   | |
 	STA .sram_pointer_bank			;$80A63D   |/
 namespace off					;	   |
 	LDA $060F				;$80A63F   |\ Check which controller is active
 	BEQ .copy_player_1			;$80A642   |/
 	LDA .sram_pointer			;$80A644   |\ Skip $14E bytes of the file
 	CLC					;$80A646   | |
-	ADC #sizeof(subfile)			;$80A647   | |
+	ADC.w #sizeof(subfile)			;$80A647   | |
 	STA .sram_pointer			;$80A64A   |/
 .copy_player_1					;	   |
 	%pea_use_dbr(sram_file_buffer)		;$80A64C   |\ Swap out dbr to access full wram
 	PLB					;$80A64F   |/
-	LDY #sizeof(subfile)-2			;$80A650   | Load subfile length
+	LDY.w #sizeof(subfile)-2			;$80A650   | Load subfile length
 .copy_sram					;	   |
 	LDA.w sram_file_buffer,y		;$80A653   |\ Simple copy loop from the SRAM buffer to actual SRAM
 	STA [.sram_pointer],y			;$80A656   | |
@@ -4309,7 +4309,7 @@ run_file_select:				;	  \
 	TAX					;$80A938   | |
 	LDA.l .sram_file_offsets,x		;$80A939   | |
 	STA $54					;$80A93D   | |
-	LDA #<:sram_base			;$80A93F   | |
+	LDA.w #<:sram_base			;$80A93F   | |
 	STA $56					;$80A942   |/
 	LDA.l DATA_80A866,x			;$80A944   |\ Get the VRAM offset of the target file line
 	LDX file_select_selection		;$80A948   |/
@@ -4590,7 +4590,7 @@ namespace off					;	   |/
 	TAX					;$80AB7F   |/
 	LDA.l .sram_file_offsets,x		;$80AB80   |\ Setup pointer to the active save file
 	STA .sram_pointer			;$80AB84   | |
-	LDA #<:sram_base			;$80AB86   | |
+	LDA.w #<:sram_base			;$80AB86   | |
 	STA .sram_pointer_bank			;$80AB89   |/
 	LDY.w #save_file.additive_checksum	;$80AB8B   |\ Increment the first byte which will cause the sram
 	LDA [.sram_pointer],y			;$80AB8E   | | file to no longer verify properly
@@ -4613,16 +4613,16 @@ namespace off					;	   |/
 	TAX					;$80ABB4   |/
 	LDA.l .sram_file_offsets,x		;$80ABB5   |\ Setup pointer to the active save file
 	STA .sram_pointer			;$80ABB9   | |
-	LDA #<:sram_base			;$80ABBB   | |
+	LDA.w #<:sram_base			;$80ABBB   | |
 	STA .sram_pointer_bank			;$80ABBE   |/
 	LDA file_select_file_to_copy		;$80ABC0   |\ Calculate the index to the file to copy from
 	ASL A					;$80ABC3   | |
 	TAX					;$80ABC4   |/
 	LDA.l .sram_file_offsets,x		;$80ABC5   |\ Setup pointer to the file to copy from
 	STA .sram_pointer_original		;$80ABC9   | |
-	LDA #<:sram_base			;$80ABCB   | |
+	LDA.w #<:sram_base			;$80ABCB   | |
 	STA .sram_pointer_bank_original		;$80ABCE   |/
-	LDY #sizeof(save_file)-2		;$80ABD0   | Load the size of the save file
+	LDY.w #sizeof(save_file)-2		;$80ABD0   | Load the size of the save file
 ..copy_sram					;	   |
 	LDA [.sram_pointer_original],y		;$80ABD3   |\ Copy two bytes at a time from the original file to the
 	STA [.sram_pointer],y			;$80ABD5   | | New file
@@ -4648,11 +4648,11 @@ namespace off					;	   |/
 	TAX					;$80ABFB   |/
 	LDA.l .sram_file_offsets,x		;$80ABFC   |\ Setup pointer to the active save file
 	STA .sram_pointer			;$80AC00   | |
-	LDA #<:sram_base			;$80AC02   | |
+	LDA.w #<:sram_base			;$80AC02   | |
 	STA .sram_pointer_bank			;$80AC05   |/
 	%pea_use_dbr(sram_file_buffer)		;$80AC07   |\ Switch the dbr to the sram bank
 	PLB					;$80AC0A   |/
-	LDY #sizeof(save_file)			;$80AC0B   | Load the size of the save file, loads 2 extra bytes
+	LDY.w #sizeof(save_file)			;$80AC0B   | Load the size of the save file, loads 2 extra bytes
 ..copy_sram					;	   |
 	LDA [.sram_pointer],y			;$80AC0E   |\ Copy two bytes at a time from the save file save buffer
 	STA.w sram_file_buffer,y		;$80AC10   | |
@@ -4701,7 +4701,7 @@ upload_channel_count_tilemap:			;	  \
 	RTS					;$80AC62  /
 
 upload_file_tilemaps:
-	LDA #<:save_file1			;$80AC63  \
+	LDA.w #<:save_file1			;$80AC63  \
 	STA $56					;$80AC66   |
 	LDA #$0000				;$80AC68   |
 	JSR get_file_status			;$80AC6B   |
@@ -5545,7 +5545,7 @@ init_title_screen:
 	INY					;$80B42C   | Increment the initial sparkle frame for the next sparkle
 	TXA					;$80B42D   |\ Calculate the next sprite slot
 	CLC					;$80B42E   | |
-	ADC #sizeof(sprite)			;$80B42F   | |
+	ADC.w #sizeof(sprite)			;$80B42F   | |
 	TAX					;$80B432   | |
 	CMP #$0F5A				;$80B433   | |
 	BNE .next_sprite_slot			;$80B436   |/
@@ -5611,7 +5611,7 @@ run_title_screen:				;	  \
 	STA $1A,x				;$80B4B9   | Set the sparkles display frame
 	TXA					;$80B4BB   |\ Calculate the next sprite slot
 	CLC					;$80B4BC   | |
-	ADC #sizeof(sprite)			;$80B4BD   | |
+	ADC.w #sizeof(sprite)			;$80B4BD   | |
 	TAX					;$80B4C0   | |
 	CMP #main_sprite_table_end		;$80B4C1   | |
 	BNE .next_sprite_slot			;$80B4C4   |/
@@ -5813,18 +5813,18 @@ run_nintendo_copyright:				;	  \
 
 ;$80B6C1
 level_nmi_table:
-	dw CODE_80B705				;00 
+	dw CODE_80B705				;00
 	dw CODE_80B746				;01 Forest (Unused)
 	dw CODE_80B779				;02 Ship Hold
 	dw CODE_80B7A6				;03 Wasp Hive
-	dw CODE_80B95F				;04 
-	dw CODE_80B720				;05 
+	dw CODE_80B95F				;04
+	dw CODE_80B720				;05
 	dw CODE_80B977				;06 Ship Deck
 	dw CODE_80B9C6				;07 Lava
 	dw CODE_80BB77				;08 Ship Mast (Rain)
 	dw CODE_80BBD5				;09 Roller Coaster
 	dw CODE_80BC3D				;0A Ship Deck (Cabin)
-	dw CODE_80BC6D				;0B 
+	dw CODE_80BC6D				;0B
 	dw CODE_80BC85				;0C Mine
 	dw CODE_80BDAA				;0D Ship Mast (Clouds)
 	dw CODE_80BE9C				;0E Forest (Lights)
@@ -6753,7 +6753,7 @@ CODE_80BF1A:					;	   |
 	STA $7E8013				;$80BF1A   |
 	LDA $17C0				;$80BF1E   |
 	CLC					;$80BF21   |
-	ADC #sizeof(sprite)			;$80BF22   |
+	ADC.w #sizeof(sprite)			;$80BF22   |
 	SEC					;$80BF25   |
 	SBC $0AFE				;$80BF26   |
 	BPL CODE_80BF2E				;$80BF29   |
@@ -9018,18 +9018,18 @@ DATA_80D3ED:
 
 ;$80D411
 level_logic_table:
-	dw CODE_80D45A				;00 
+	dw CODE_80D45A				;00
 	dw CODE_80D462				;01 Forest (Unused)
 	dw CODE_80D486				;02 Ship Hold
 	dw CODE_80D557				;03 Wasp Hive
-	dw CODE_80D58C				;04 
-	dw CODE_80D451				;05 
+	dw CODE_80D58C				;04
+	dw CODE_80D451				;05
 	dw CODE_80D595				;06 Ship Deck
 	dw CODE_80D5C3				;07 Lava
 	dw CODE_80D5E7				;08 Ship Mast
 	dw CODE_80D61B				;09 Roller Coaster
 	dw CODE_80D642				;0A Ship Deck (Cabin)
-	dw CODE_80D665				;0B 
+	dw CODE_80D665				;0B
 	dw CODE_80D66E				;0C Mine
 	dw CODE_80D784				;0D Forest (Lights)
 	dw CODE_80D7AB				;0E Forest (Windy)
@@ -13202,7 +13202,7 @@ CODE_80F946:
 	TAX					;$80F951   |
 	LDA.l DATA_80F70C,x			;$80F952   |
 	STA $3A					;$80F956   |
-	LDA #<:DATA_80F70C			;$80F958   |
+	LDA.w #<:DATA_80F70C			;$80F958   |
 	STA $3C					;$80F95B   |
 	LDY #$0000				;$80F95D   |
 CODE_80F960:					;	   |
@@ -13482,7 +13482,7 @@ CODE_80FB9E:
 	JML CODE_BBBEA0				;$80FB9E  /
 bank_80_end:
 
-warnpc $80FFB0
+assert pc() <= $80FFB0
 org $80FFB0
 
 DATA_80FFB0:

--- a/bank_B3.asm
+++ b/bank_B3.asm
@@ -13,9 +13,9 @@ sprite_handler:
 	STZ $19AC				;$B3801B   |
 	STZ $19AF				;$B3801E   |
 	REP #$20				;$B38021   |
-	LDA #<:.sprite_return			;$B38023   |\ Write bank of sprite return address (always B3)
+	LDA.w #<:.sprite_return			;$B38023   |\ Write bank of sprite return address (always B3)
 	STA $05AB				;$B38026   |/
-	LDA #<:DATA_FF0000			;$B38029   |\ Write bank of sprite constants for current sprite (always FF)
+	LDA.w #<:DATA_FF0000			;$B38029   |\ Write bank of sprite constants for current sprite (always FF)
 	STA $90					;$B3802C   |/
 	JSL CODE_BCFA78				;$B3802E   |
 	LDA $0A36				;$B38032   |\
@@ -38,7 +38,7 @@ sprite_handler:
 .get_next_slot					;	   |
 	TXA					;$B38054   |\ Load next sprite slot
 	CLC					;$B38055   | |
-	ADC #sizeof(sprite)			;$B38056   | |
+	ADC.w #sizeof(sprite)			;$B38056   | |
 	TAX					;$B38059   |/
 	CPX #main_sprite_table_end		;$B3805A   |\ If not at the last sprite
 	BNE .next_slot				;$B3805D   |/ then test if the sprite exists
@@ -112,7 +112,7 @@ CODE_B380D5:
 CODE_B380D7:					;	   |
 	TXA					;$B380D7   |
 	CLC					;$B380D8   |
-	ADC #sizeof(sprite)			;$B380D9   |
+	ADC.w #sizeof(sprite)			;$B380D9   |
 	TAX					;$B380DC   |
 	CPX #main_sprite_table_end		;$B380DD   |
 	BNE CODE_B38090				;$B380E0   |
@@ -327,7 +327,7 @@ diddy_hurt_stars_main:
 	LDX current_sprite			;$B3826C   | Get hurt star sprite
 	LDA $42,x				;$B3826E   | Get time until despawn
 	BEQ .return				;$B38270   | If already finished, return
-	DEC $42,x				;$B38272   | Else decrease it 
+	DEC $42,x				;$B38272   | Else decrease it
 	BEQ .delete_hurt_star_sprite		;$B38274   | If 0, delete sprite
 .return:					;	   |
 	JML [$05A9]				;$B38276  / Else done processing sprite
@@ -994,7 +994,7 @@ sprite_fg_occluder_main:
 	JSR .CODE_B388EA			;$B388D6   |
 	LDY inactive_kong_sprite		;$B388D9   | Get inactive kong sprite
 	JSR .CODE_B388EA			;$B388DC   |
-	LDY current_player_mount		;$B388DF   | Get animal that kong is riding 
+	LDY current_player_mount		;$B388DF   | Get animal that kong is riding
 	BEQ .return				;$B388E1   | If it doesn't exist, return
 	JSR .CODE_B388EA			;$B388E3   |
 .return:					;	   | Else
@@ -1066,10 +1066,10 @@ CODE_B3894F:
 ;bit 6 = is platform moving (set via animation code)
 ;bit 7 = is platform opening (set via animation code)
 
-web_platform_main:  
+web_platform_main:
 	LDX current_sprite			;$B38959  \ get web platform sprite
-	LDA $2E,x				;$B3895B   | get sprite action index 
-	ASL A					;$B3895D   |	
+	LDA $2E,x				;$B3895B   | get sprite action index
+	ASL A					;$B3895D   |
 	TAX					;$B3895E   |
 	JMP (.state_table,x)			;$B3895F  / get sprite action from table
 
@@ -1087,7 +1087,7 @@ web_platform_main:
 	JSL CODE_B9D100				;$B38977   | Process animation
 	BRA .done_processing			;$B3897B  / Done processing sprite
 
-.despawn	
+.despawn
 	LDA #$00C0				;$B3897D  \ \
 	TRB $0B02				;$B38980   |/ Clear bits 6 and 7 (so more webs can be shot)
 	JML [$05A9]				;$B38983  /> Done processing sprite
@@ -1110,7 +1110,7 @@ web_platform_main:
 	JML [$05A9]				;$B389A1  /> Done processing sprite
 
 .brl_despawn
-	BRA .despawn				;$B389A4  / 
+	BRA .despawn				;$B389A4  /
 
 .platform_idle_state
 	LDX current_sprite			;$B389A6  \> Get web platform sprite
@@ -1183,7 +1183,7 @@ update_web_velocity:
 	CLC					;$B38A1E  \ \
 	ADC $24,x				;$B38A1F   |/ Add Y velocity to Y trajectory
 	CMP #$0600				;$B38A21   |\
-	BMI ..apply_velocity			;$B38A24   |/ Make sure velocity doesnt overflow 
+	BMI ..apply_velocity			;$B38A24   |/ Make sure velocity doesnt overflow
 	LDA #$0600				;$B38A26   |> Velocity overflowed, cap it
 ..apply_velocity				;	   |
 	STA $24,x				;$B38A29   |> Update current Y velocity
@@ -2837,7 +2837,7 @@ lilypad_main:
 	LDX current_sprite			;$B395F8  \ get lilypad sprite
 	LDY $42,x				;$B395FA   | get address of horsetail sprite that spawned it
 	LDA $0000,y				;$B395FC   | check its ID
-	CMP #!sprite_horsetail			;$B395FF   | 
+	CMP #!sprite_horsetail			;$B395FF   |
 	BNE .delete_sprite			;$B39602   | if there's a mismatch, delete lilypad sprite
 	LDA $004C,y				;$B39604   | else get address of self from horsetail
 	CMP current_sprite			;$B39607   | check if its the currently processing sprite
@@ -3690,7 +3690,7 @@ CODE_B39C79:
 	JSR CODE_B39C39				;$B39C8D   |
 	TXA					;$B39C90   |
 	SEC					;$B39C91   |
-	SBC #sizeof(sprite)			;$B39C92   |
+	SBC.w #sizeof(sprite)			;$B39C92   |
 	STA current_sprite			;$B39C95   |
 CODE_B39C97:					;	   |
 	JML [$05A9]				;$B39C97  /
@@ -4214,7 +4214,7 @@ endif						;	   |
 .next_slot:					;	   |
 	TXA					;$B3A05D   |
 	CLC					;$B3A05E   |
-	ADC #sizeof(sprite)			;$B3A05F   |
+	ADC.w #sizeof(sprite)			;$B3A05F   |
 	TAX					;$B3A062   |
 	CPX #main_sprite_table_end		;$B3A063   |
 	BNE .continue_scanning			;$B3A066   | If not at the end of sprite table continue scanning
@@ -4232,7 +4232,7 @@ endif						;	   |
 	ADC #$0008				;$B3A07E   | Offset by 8 pixels downwards
 	CMP $0A,x				;$B3A081   | Compare with kong/animal's Y position
 	BMI .return				;$B3A083   | If negative, kong/animal is below the sign, return
-	LDA $0006,y				;$B3A085   | 
+	LDA $0006,y				;$B3A085   |
 	SEC					;$B3A088   | Else get distance between kong/animal and the sign
 	SBC $06,x				;$B3A089   |
 	BPL .positive				;$B3A08B   | If positive distance don't invert
@@ -4243,7 +4243,7 @@ endif						;	   |
 	BPL .return				;$B3A094   | If not, return
 	LDA $6E					;$B3A096   | Else get current animal ID
 	BEQ .despawn_standalone_animal		;$B3A098   | If it doesn't exist its a standalone animal
-	LDA #$0019				;$B3A09A   | 
+	LDA #$0019				;$B3A09A   |
 	JSL set_player_interaction_global	;$B3A09D   | Else set player interaction to "transform animal into item"
 	BCS .return				;$B3A0A1   |
 	LDX current_sprite			;$B3A0A3   | Get sign sprite
@@ -4273,7 +4273,7 @@ endif
 
 ;Goal prize variables:
 ;$42,x	index of goal target sprite
-;$44,x	index into reward sequence 
+;$44,x	index into reward sequence
 ;$46,x	reward display timer
 ;$48,x  index of reward graphic ID
 ;$4A,x	timer until prize drops down
@@ -4335,7 +4335,7 @@ level_goal_prize_main:
 .state_2:
 	LDX current_sprite			;$B3A124  \ Get prize sprite
 	INC $2E,x				;$B3A126   | Set state 3 (wait for drop)
-	LDA #$000F				;$B3A128   | 
+	LDA #$000F				;$B3A128   |
 	STA $4A,x				;$B3A12B   | Setup timer for state 3
 	BRA .return				;$B3A12D  / Done processing sprite
 
@@ -4399,7 +4399,7 @@ level_goal_prize_main:
 	TAY					;$B3A192   | Transfer index to Y
 	LDA [$8E],y				;$B3A193   |
 	AND #$00FF				;$B3A195   | Get low byte (display timer)
-	STA $46,x				;$B3A198   | 
+	STA $46,x				;$B3A198   |
 	INY					;$B3A19A   | Move Y to next byte
 	LDA [$8E],y				;$B3A19B   |
 	AND #$00FF				;$B3A19D   | Get low byte (index of reward graphic ID)
@@ -4481,7 +4481,7 @@ level_goal_barrel_main:
 	STA $0A,x				;$B3A20F   | Else set it back to initial Y position
 ..check_if_max_height:				;	   |
 	LDA $44,x				;$B3A211   |
-	SEC					;$B3A213   | 
+	SEC					;$B3A213   |
 	SBC $0A,x				;$B3A214   | Subtract current Y position from initial Y position...
 	CMP #$0060				;$B3A216   | To check if barrel reached the max height
 	BPL ..break_barrel			;$B3A219   | If yes, spawn particles and delete barrel sprite
@@ -4497,7 +4497,7 @@ level_goal_prop_check_parent:
 	LDA $42,x				;$B3A229   | Get index of sprite that spawned it
 	TAY					;$B3A22B   |
 	LDA $0000,y				;$B3A22C   | Get its ID
-	CMP #!sprite_level_goal			;$B3A22F   | 
+	CMP #!sprite_level_goal			;$B3A22F   |
 	BNE CODE_B3A236				;$B3A232   | If not the level goal, return with bad nes
 	CLC					;$B3A234   | Else tell caller everything is OK
 	RTS					;$B3A235  / Return
@@ -4512,7 +4512,7 @@ CODE_B3A236:
 ;$44,x 	index of pole sprite
 ;$46,x	index of prize sprite
 ;$48,x 	unclear
-;$4A,x	mirror of Y position obtained from CODE_B8D47C	
+;$4A,x	mirror of Y position obtained from CODE_B8D47C
 level_goal_main:
 	LDX current_sprite			;$B3A238  \
 	LDA $54,x				;$B3A23A   |
@@ -4542,7 +4542,7 @@ level_goal_main:
 	JSL CODE_BB842C				;$B3A25F   | Spawn prop barrel sprite
 	LDY alternate_sprite			;$B3A263   | Get barrel we just spawned
 	LDA current_sprite			;$B3A265   | Get goal sprite
-	TAX					;$B3A267   | 
+	TAX					;$B3A267   |
 	STA $0042,y				;$B3A268   | Store index of goal into barrel
 	TYA					;$B3A26B   |
 	STA $42,x				;$B3A26C   | Store index of barrel into goal
@@ -4568,7 +4568,7 @@ level_goal_main:
 
 .idle_state:
 	LDX active_kong_sprite			;$B3A299  \ Get active kong sprite
-	LDA $1E,x				;$B3A29C   | 
+	LDA $1E,x				;$B3A29C   |
 	AND #$0101				;$B3A29E   | Check if kong is grounded
 	BNE ..return				;$B3A2A1   | If yes, return
 	LDA $24,x				;$B3A2A3   | Else get their Y velocity
@@ -4580,7 +4580,7 @@ level_goal_main:
 ..handle_collision:				;	   |
 	JSL CODE_BCFB58				;$B3A2AF   | Else populate sprite clipping
 	LDA #$0008				;$B3A2B3   | Load collision flags
-	JSL CODE_BCFCB5				;$B3A2B6   | Check collision with kong 
+	JSL CODE_BCFCB5				;$B3A2B6   | Check collision with kong
 	BCS ..collision_happened		;$B3A2BA   | If collision happened
 ..return:					;	   |
 	JMP CODE_B38000				;$B3A2BC  / Else done processing sprite
@@ -4589,14 +4589,14 @@ level_goal_main:
 	LDX current_sprite			;$B3A2BF  \ Get goal sprite
 	INC $2E,x				;$B3A2C1   | Set state 2 (idle)
 	LDY $42,x				;$B3A2C3   | Get barrel sprite
-	LDA #$0002				;$B3A2C5   | 
+	LDA #$0002				;$B3A2C5   |
 	STA $002E,y				;$B3A2C8   | Set its state to 2 (transitions to state 3)
 	LDA #$0004				;$B3A2CB   |
 	TRB $0B02				;$B3A2CE   |
 	PHX					;$B3A2D1   | Preserve goal sprite and barrel sprite...
 	PHY					;$B3A2D2   | ...for no reason, routine below won't ditch them
 	JSR .check_if_should_drop_prize		;$B3A2D3   | Check if we should drop the prize
-	PLY					;$B3A2D6   | 
+	PLY					;$B3A2D6   |
 	PLX					;$B3A2D7   |
 	STA $0024,y				;$B3A2D8   | Set barrel Y velocity gotten from routine above
 	BCS ..dont_drop_prize			;$B3A2DB   | If the routine gave us a no, skip dropping the prize
@@ -5404,9 +5404,9 @@ endif						;	   |
 	LDA $32,x				;$B3A883   |\ Get carry interaction
 	STZ $32,x				;$B3A885   |/ Clear carry interaction
 	CMP #$0001				;$B3A887   |\
-	BEQ ..put_down				;$B3A88A   |/ If click-clack was just put down then 
+	BEQ ..put_down				;$B3A88A   |/ If click-clack was just put down then
 	CMP #$0002				;$B3A88C   |\
-	BEQ ..thrown				;$B3A88F   |/ If click-clack was just thrown then 
+	BEQ ..thrown				;$B3A88F   |/ If click-clack was just thrown then
 	CMP #$0005				;$B3A891   |\
 	BNE ..still_held			;$B3A894   |/ If kong wasnt hit whilst holding click-clack,
 ..put_down					;	   |
@@ -7599,18 +7599,18 @@ force_sprite_submerged:
 	LDX current_sprite			;$B3B887  \
 	LDA $0D4E				;$B3B889   | Get water Y position
 	CLC					;$B3B88C   |
-	ADC #$0018				;$B3B88D   | Offset it downwards by 24 pixels 
+	ADC #$0018				;$B3B88D   | Offset it downwards by 24 pixels
 	STA $32					;$B3B890   | Save it in scratch ram
 	CMP $44,x				;$B3B892   | Compare with sprite's Y home position
 	BCC .home_submerged			;$B3B894   | If home position is in the water
-	LDY $44,x				;$B3B896   | Else get home position 
+	LDY $44,x				;$B3B896   | Else get home position
 	STA $44,x				;$B3B898   | Cap it to water height threshold (just below water)
 	CMP $0A,x				;$B3B89A   | Check if sprite is above threshold
 	BCC .sprite_submerged			;$B3B89C   | If not
 	TYA					;$B3B89E   | Else transfer initial home position to A
 	SBC $44,x				;$B3B89F   | Get distance between old and new home position
 	EOR #$FFFF				;$B3B8A1   | Invert it
-	SEC					;$B3B8A4   | 
+	SEC					;$B3B8A4   |
 	ADC $0A,x				;$B3B8A5   | Add difference to sprite's Y position
 	STA $0A,x				;$B3B8A7   | And apply it
 	BRA .sprite_submerged			;$B3B8A9  /
@@ -7680,7 +7680,7 @@ flotsam_main:
 ..submerged:
 	TYX					;$B3B90D  \ Transfer flotsam sprite to X
 	INC $2E,x				;$B3B90E   | Set state 1
-.state_1:					;	   | 
+.state_1:					;	   |
 	INC $19AC				;$B3B910   | play flotsam looping sound
 	LDA #$0118				;$B3B913   |
 	JSL check_throwable_collision_global	;$B3B916   |
@@ -8490,18 +8490,18 @@ kannon_main:
 	EOR #$4000				;$B3BEBC   | | Make kannon face towards attacker
 	STA $12,x				;$B3BEBF   |/
 	LDA #$0100				;$B3BEC1   | Load an X velocity
-	BIT $12,x				;$B3BEC4   | 
+	BIT $12,x				;$B3BEC4   |
 	BVS ..set_velocities			;$B3BEC6   | If kannon is now facing left, store velocity
 	LDA #$FF00				;$B3BEC8   | Else load negative X velocity
 ..set_velocities:				;	   |
-	STA $26,x				;$B3BECB   | 
+	STA $26,x				;$B3BECB   |
 	STA $20,x				;$B3BECD   | Set current and target X velocities
 	LDA #$FA00				;$B3BECF   |
 	STA $24,x				;$B3BED2   | Set current Y velocity
 	LDA #$0004				;$B3BED4   |
 	STA $52,x				;$B3BED7   | Set "defeated" movement routine
 	LDA #$017F				;$B3BED9   | Load kannon death animation
-	JSR defeat_sprite_using_animation	;$B3BEDC   | 
+	JSR defeat_sprite_using_animation	;$B3BEDC   |
 	LDA #$0001				;$B3BEDF   |
 	STA $2E,x				;$B3BEE2   | Set defeated state
 	SEC					;$B3BEE4   | Tell caller collision happened
@@ -8533,7 +8533,7 @@ kannon_main:
 	LDX alternate_sprite			;$B3BF17   | Get projectile we just spawned
 	INY					;$B3BF19   |
 	INY					;$B3BF1A   | Move to next word of pattern data
-	LDA [$32],y				;$B3BF1B   | 
+	LDA [$32],y				;$B3BF1B   |
 	AND #$00FF				;$B3BF1D   | Get low byte (projectile speed preset)
 	STA $50,x				;$B3BF20   | And pass it to projectile
 	LDX current_sprite			;$B3BF22   | Get kannon sprite
@@ -8552,14 +8552,14 @@ kannon_main:
 	CLC					;$B3BF38   |
 	ADC #$0010				;$B3BF39   | Offset by 16 pixels
 	STA $004E,y				;$B3BF3C   | Pass to projectile
-	LDA $4E,x				;$B3BF3F   | 
+	LDA $4E,x				;$B3BF3F   |
 	STA $005A,y				;$B3BF41   | Set projectile's offscreen despawn timer
 	LDA #$054B				;$B3BF44   |
 	JSL queue_sound_effect			;$B3BF47   | Play cannon_shoot sound effect
-	LDY #$0008				;$B3BF4B   | 
+	LDY #$0008				;$B3BF4B   |
 	LDA [$8E],y				;$B3BF4E   | Get index of smoke puff script in kannon constants
 	TAY					;$B3BF50   | Transfer it to Y
-	JSL CODE_BB842C				;$B3BF51   | And spawn it 
+	JSL CODE_BB842C				;$B3BF51   | And spawn it
 	CLC					;$B3BF55   | Tell caller the projectile spawn succeeded
 ..return:					;	   |
 	RTS					;$B3BF56  / Return
@@ -9191,7 +9191,7 @@ extra_life_balloon_main:
 
 .idle_state:
 	LDA $0A36				;$B3C40E  \ Get timestop flags
-	BIT #$0004				;$B3C411   | 
+	BIT #$0004				;$B3C411   |
 	BNE .return				;$B3C414   | If timestop running, return
 	JSL CODE_BCFB58				;$B3C416   | Else populate sprite clipping
 	JSL CODE_BEBE6D				;$B3C41A   | Check simple player collision
@@ -9199,7 +9199,7 @@ extra_life_balloon_main:
 .handle_floating:				;	   |
 	JSL CODE_B9D100				;$B3C420   | Else process animation
 	LDA $04,x				;$B3C424   | Get timer until balloon starts floating
-	CMP #$8000				;$B3C426   | 
+	CMP #$8000				;$B3C426   |
 	BEQ .return_handle_despawn		;$B3C429   |
 	JSL process_current_movement		;$B3C42B   |
 	LDA $52,x				;$B3C42F   | Get movement behavior
@@ -9234,7 +9234,7 @@ extra_life_balloon_main:
 	JSL CODE_BCFB58				;$B3C46E   | Else populate sprite clipping
 	JSL CODE_BEBE6D				;$B3C472   | Check simple player collision
 	BCC .handle_floating			;$B3C476   | If no collision, handle floating
-	LDA #$0010				;$B3C478   | 
+	LDA #$0010				;$B3C478   |
 	TSB $0902				;$B3C47B   | Else set it as collected
 	BRA .collect_balloon			;$B3C47E  / And collect the balloon
 
@@ -11546,7 +11546,7 @@ rideable_balloon_main:
 	INC $2E,x				;$B3D594   | Init done
 .state_1:					;	   |
 	JSL CODE_BBBB7B				;$B3D596   | Check if sprite has gone offscreen
-	BCC ..CODE_B3D59F			;$B3D59A   | If not... 
+	BCC ..CODE_B3D59F			;$B3D59A   | If not...
 	JMP CODE_B38000				;$B3D59C  /  Else done processing sprite
 
 ..CODE_B3D59F:
@@ -11706,7 +11706,7 @@ DATA_B3D691:
 	dw $2701
 	dw $8000
 
-;bonus 2 steam vents	
+;bonus 2 steam vents
 	dw $0000
 	dw $0160
 	dw $0181
@@ -12047,7 +12047,7 @@ clapper_sprite_code:
 	BCC .water_into_ice			;$B3D951   |> If clapper is above water then do default transition
 	LDA #$00C0				;$B3D953   |\ Else slow down animation speed, clapper is submerged
 	STA $003A,y				;$B3D956   |/
-	LDA $0036,y				;$B3D959   |\ 
+	LDA $0036,y				;$B3D959   |\
 	CMP #$01B8				;$B3D95C   | |
 	BEQ .return				;$B3D95F   |/ If already clapping then skip collision check with kong
 	JSL CODE_BCFB58				;$B3D961   |\ Prepare hitbox for collision...
@@ -12055,7 +12055,7 @@ clapper_sprite_code:
 	BCC .return				;$B3D969   |> If no collision happened then return
 	LDA #$FE00				;$B3D96B   |\ Else apply a Y velocity to kong
 	STA $0024,y				;$B3D96E   |/
-	BRA .set_clapping_animation		;$B3D971  /> Set clapping animation and return 
+	BRA .set_clapping_animation		;$B3D971  /> Set clapping animation and return
 
 .water_into_ice
 	LDA #$0100				;$B3D973  \ \ Set normal animation speed
@@ -12078,12 +12078,12 @@ clapper_sprite_code:
 .collision_happened
 	LDX current_sprite			;$B3D99D  \ \
 	LDA $46,x				;$B3D99F   | | Restore the previously copied OAM properties
-	STA $12,x				;$B3D9A1   |/ 
+	STA $12,x				;$B3D9A1   |/
 	LDA #$001E				;$B3D9A3   |\
 	CMP $0A82				;$B3D9A6   |/ Check if the kong is being knocked back
 	BEQ .kong_knocked_back			;$B3D9A9   |\ If kong is being knocked back
 	BRA .set_clapping_animation		;$B3D9AB  /_/ Play clapping animation
-	
+
 	JSL set_player_interaction_global	;$B3D9AD  \ \ Dead code?
 	BCS .set_clapping_animation		;$B3D9B1   |/ Dead code?
 .kong_knocked_back				;	   |
@@ -13893,7 +13893,7 @@ barrel_icons_sprite_code:
 	LDA $4C,x				;$B3E6CD   | Else get time until next graphic swap
 	BEQ ..CODE_B3E6D4			;$B3E6CF   | If timer done then
 	DEC $4C,x				;$B3E6D1   | Else count it down
-..return:					;	   | 
+..return:					;	   |
 	RTS					;$B3E6D3  /
 
 ..CODE_B3E6D4:
@@ -13923,7 +13923,7 @@ barrel_icons_sprite_code:
 	LDA $003C,y				;$B3E6FB   | Else get index of self in the barrel
 	CMP current_sprite			;$B3E6FE   | Check if its still the currently processing sprite
 	BNE ..sprite_mismatched			;$B3E700   | If not, return with the bad news
-	LDA $002A,y				;$B3E702   | Else 
+	LDA $002A,y				;$B3E702   | Else
 	STA $2A,x				;$B3E705   |
 	AND #$1000				;$B3E707   |
 	BNE ..CODE_B3E718			;$B3E70A   | If active kong touched the barrel...
@@ -13975,7 +13975,7 @@ barrel_icons_sprite_code:
 	LDX current_sprite			;$B3E74E   | Get icon sprite
 	LDY $42,x				;$B3E750   | Get barrel sprite
 	LDA $0044,y				;$B3E752   | Get number barrel timer
-	XBA					;$B3E755   | 
+	XBA					;$B3E755   |
 	AND #$0007				;$B3E756   | Get number
 	BEQ ..number_is_0			;$B3E759   | If 0, reset to default graphic ID
 	DEC A					;$B3E75B   |
@@ -14011,7 +14011,7 @@ barrel_cannon_code:
 	dw .state_A				;0A rotating back?
 	dw .state_B				;0B rotated into place?
 	dw .state_C				;0C transforming into animal
-	dw .state_D				;0D decrement $38,x 
+	dw .state_D				;0D decrement $38,x
 	dw .state_E				;0E only spawn if exiting bonus
 
 

--- a/bank_B4.asm
+++ b/bank_B4.asm
@@ -3,7 +3,7 @@ CODE_B48000:					;	   |
 	PHK					;$B48001   |
 	PLB					;$B48002   |
 	SEP #$20				;$B48003   |
-	LDA #<:wram_base			;$B48005   |
+	LDA.b #<:wram_base			;$B48005   |
 	STA $CA					;$B48007   |
 	REP #$20				;$B48009   |
 	STZ $08CC				;$B4800B   |
@@ -75,7 +75,7 @@ CODE_B480B2:
 	STY $CE					;$B480B2  \
 	STA $0650				;$B480B4   |
 	SEP #$20				;$B480B7   |
-	LDA #<:wram_base			;$B480B9   |
+	LDA.b #<:wram_base			;$B480B9   |
 	STA $D0					;$B480BB   |
 	REP #$20				;$B480BD   |
 	LDA #$0000				;$B480BF   |
@@ -93,7 +93,7 @@ CODE_B480CD:
 	PHK					;$B480CE   |
 	PLB					;$B480CF   |
 	SEP #$20				;$B480D0   |
-	LDA #<:wram_base			;$B480D2   |
+	LDA.b #<:wram_base			;$B480D2   |
 	STA $CA					;$B480D4   |
 	PHK					;$B480D6   |
 	PLA					;$B480D7   |
@@ -200,7 +200,7 @@ CODE_B481A6:					;	   |
 	STX HDMA[2].settings			;$B481B0   |
 	LDX #$8012				;$B481B3   |
 	STX HDMA[2].source			;$B481B6   |
-	LDA #<:wram_base			;$B481B9   |
+	LDA.b #<:wram_base			;$B481B9   |
 	STA HDMA[2].source_bank			;$B481BB   |
 	STZ HDMA[2].indirect_source_bank	;$B481BE   |
 	REP #$20				;$B481C1   |
@@ -574,7 +574,7 @@ CODE_B484BC:					;	   |
 	STA DMA[0].destination			;$B484E0   |
 	LDX #$3E00				;$B484E3   |
 	STX DMA[0].source			;$B484E6   |
-	LDA #<:wram_base			;$B484E9   |
+	LDA.b #<:wram_base			;$B484E9   |
 	STA DMA[0].source_bank			;$B484EB   |
 	STZ DMA[0].unused_1			;$B484EE   |
 	LDA #$01				;$B484F1   |
@@ -1738,7 +1738,7 @@ CODE_B48EC2:
 	STA DMA[0].destination			;$B48ED1   |
 	LDX #$3E00				;$B48ED4   |
 	STX DMA[0].source			;$B48ED7   |
-	LDA #<:wram_base			;$B48EDA   |
+	LDA.b #<:wram_base			;$B48EDA   |
 	STA DMA[0].source_bank			;$B48EDC   |
 	LDX #$0180				;$B48EDF   |
 	STX DMA[0].size				;$B48EE2   |
@@ -2296,7 +2296,7 @@ CODE_B493B7:
 	STA DMA[0].destination			;$B493C6   |
 	LDX #$3E00				;$B493C9   |
 	STX DMA[0].source			;$B493CC   |
-	LDA #<:wram_base			;$B493CF   |
+	LDA.b #<:wram_base			;$B493CF   |
 	STA DMA[0].source_bank			;$B493D1   |
 	LDX #$0180				;$B493D4   |
 	STX DMA[0].size				;$B493D7   |
@@ -2855,7 +2855,7 @@ CODE_B4989F:
 	STA DMA[0].destination			;$B498AE   |
 	LDX #$3E00				;$B498B1   |
 	STX DMA[0].source			;$B498B4   |
-	LDA #<:wram_base			;$B498B7   |
+	LDA.b #<:wram_base			;$B498B7   |
 	STA DMA[0].source_bank			;$B498B9   |
 	LDX $0658				;$B498BC   |
 	STX DMA[0].size				;$B498BF   |
@@ -4015,7 +4015,7 @@ CODE_B4A21B:
 	STA DMA[0].destination			;$B4A22A   |
 	LDX #$4A00				;$B4A22D   |
 	STX DMA[0].source			;$B4A230   |
-	LDA #<:wram_base			;$B4A233   |
+	LDA.b #<:wram_base			;$B4A233   |
 	STA DMA[0].source_bank			;$B4A235   |
 	LDX #$0180				;$B4A238   |
 	STX DMA[0].size				;$B4A23B   |
@@ -4671,7 +4671,7 @@ CODE_B4A7E7:
 	STA DMA[0].destination			;$B4A7F6   |
 	LDX #$4600				;$B4A7F9   |
 	STX DMA[0].source			;$B4A7FC   |
-	LDA #<:wram_base			;$B4A7FF   |
+	LDA.b #<:wram_base			;$B4A7FF   |
 	STA DMA[0].source_bank			;$B4A801   |
 	LDX #$0180				;$B4A804   |
 	STX DMA[0].size				;$B4A807   |
@@ -4802,7 +4802,7 @@ CODE_B4A90E:
 	STA DMA[0].destination			;$B4A91D   |
 	LDX #$3E00				;$B4A920   |
 	STX DMA[0].source			;$B4A923   |
-	LDA #<:wram_base			;$B4A926   |
+	LDA.b #<:wram_base			;$B4A926   |
 	STA DMA[0].source_bank			;$B4A928   |
 	LDX #$0180				;$B4A92B   |
 	STX DMA[0].size				;$B4A92E   |
@@ -5022,7 +5022,7 @@ CODE_B4AB00:
 	STA DMA[0].destination			;$B4AB0F   |
 	LDX #$3E00				;$B4AB12   |
 	STX DMA[0].source			;$B4AB15   |
-	LDA #<:wram_base			;$B4AB18   |
+	LDA.b #<:wram_base			;$B4AB18   |
 	STA DMA[0].source_bank			;$B4AB1A   |
 	LDX #$0180				;$B4AB1D   |
 	STX DMA[0].size				;$B4AB20   |
@@ -5118,7 +5118,7 @@ CODE_B4ABEA:
 	STA DMA[0].destination			;$B4ABF9   |
 	LDX #$4600				;$B4ABFC   |
 	STX DMA[0].source			;$B4ABFF   |
-	LDA #<:wram_base			;$B4AC02   |
+	LDA.b #<:wram_base			;$B4AC02   |
 	STA DMA[0].source_bank			;$B4AC04   |
 	LDX #$0180				;$B4AC07   |
 	STX DMA[0].size				;$B4AC0A   |
@@ -5161,7 +5161,7 @@ CODE_B4AC65:
 	PHK					;$B4AC65  \
 	PLB					;$B4AC66   |
 	SEP #$20				;$B4AC67   |
-	LDA #<:wram_base			;$B4AC69   |
+	LDA.b #<:wram_base			;$B4AC69   |
 	STA $CA					;$B4AC6B   |
 	REP #$20				;$B4AC6D   |
 	LDX #DATA_B4AC84			;$B4AC6F   |
@@ -5626,7 +5626,7 @@ CODE_B4B0CF:
 	STA $0650				;$B4B0E2   |
 	LDX #$2A00				;$B4B0E5   |
 	SEP #$20				;$B4B0E8   |
-	LDA #<:wram_base			;$B4B0EA   |
+	LDA.b #<:wram_base			;$B4B0EA   |
 	STA $D0					;$B4B0EC   |
 	REP #$20				;$B4B0EE   |
 	LDA #$5992				;$B4B0F0   |
@@ -5713,7 +5713,7 @@ CODE_B4B18F:
 	PHB					;$B4B18F  \
 	STA $0650				;$B4B190   |
 	SEP #$20				;$B4B193   |
-	LDA #<:wram_base			;$B4B195   |
+	LDA.b #<:wram_base			;$B4B195   |
 	STA $D0					;$B4B197   |
 	REP #$20				;$B4B199   |
 	LDA #$5992				;$B4B19B   |
@@ -5725,7 +5725,7 @@ CODE_B4B18F:
 	LDY #DATA_B4E6D8			;$B4B1AB   |
 	STZ $0656				;$B4B1AE   |
 	SEP #$20				;$B4B1B1   |
-	LDA #<:wram_base			;$B4B1B3   |
+	LDA.b #<:wram_base			;$B4B1B3   |
 	PHA					;$B4B1B5   |
 	PLB					;$B4B1B6   |
 	XBA					;$B4B1B7   |
@@ -6011,7 +6011,7 @@ CODE_B4B3CA:					;	   |
 
 CODE_B4B3CD:
 	SEP #$20				;$B4B3CD  \
-	LDA #<:wram_base			;$B4B3CF   |
+	LDA.b #<:wram_base			;$B4B3CF   |
 	STA $D0					;$B4B3D1   |
 	REP #$20				;$B4B3D3   |
 	LDA #$5972				;$B4B3D5   |
@@ -6063,7 +6063,7 @@ CODE_B4B42D:
 
 CODE_B4B43D:
 	SEP #$20				;$B4B43D   |
-	LDA #<:wram_base			;$B4B43F   |
+	LDA.b #<:wram_base			;$B4B43F   |
 	STA $D0					;$B4B441   |
 	REP #$20				;$B4B443   |
 	LDA #$5972				;$B4B445   |
@@ -6127,7 +6127,7 @@ CODE_B4B4D3:
 	PHB					;$B4B4D3  \
 	STA $0650				;$B4B4D4   |
 	SEP #$20				;$B4B4D7   |
-	LDA #<:wram_base			;$B4B4D9   |
+	LDA.b #<:wram_base			;$B4B4D9   |
 	STA $D0					;$B4B4DB   |
 	REP #$20				;$B4B4DD   |
 	LDA #$5972				;$B4B4DF   |
@@ -6140,7 +6140,7 @@ CODE_B4B4D3:
 	LDY #DATA_B4CF4B			;$B4B4F2   |
 	SEP #$20				;$B4B4F5   |
 	LDX #$3200				;$B4B4F7   |
-	LDA #<:wram_base			;$B4B4FA   |
+	LDA.b #<:wram_base			;$B4B4FA   |
 	PHA					;$B4B4FC   |
 	PLB					;$B4B4FD   |
 	XBA					;$B4B4FE   |
@@ -6820,7 +6820,7 @@ CODE_B4B9F6:
 CODE_B4B9F9:					;	   |
 	STA $0656				;$B4B9F9   |
 	SEP #$20				;$B4B9FC   |
-	LDA #<:wram_base			;$B4B9FE   |
+	LDA.b #<:wram_base			;$B4B9FE   |
 	STA $D0					;$B4BA00   |
 	REP #$20				;$B4BA02   |
 CODE_B4BA04:					;	   |

--- a/bank_B5.asm
+++ b/bank_B5.asm
@@ -682,7 +682,7 @@ endif						;	   | |/
 	RTS					;$B5848F  /
 
 
-warnpc $B59C00 : padbyte $00 : pad $B59C00
+assert pc() <= $B59C00 : padbyte $00 : pad $B59C00
 
 
 ;$32	(byte)	OAM render properties
@@ -705,7 +705,7 @@ CODE_B59C00:
 	LDA $1730				;$B59C04   |\ Get next free slot in sprite DMA buffer
 	CMP $78					;$B59C07   | | Compare to DMA buffer cap
 	BCC .free_slot_in_buffer		;$B59C09   |/ If there are more slots in the DMA buffer then continue
-	RTL					;$B59C0B  /> Else return and dont queue sprite graphic for DMA 
+	RTL					;$B59C0B  /> Else return and dont queue sprite graphic for DMA
 
 .free_slot_in_buffer
 	STX $18,y				;$B59C0C  \ \ Store delayed mirrors of sprite graphics number
@@ -5278,14 +5278,14 @@ DATA_B5BD05:
 	dw $0020, $2F00, $0000, $0200, $0000	; 00 web woods
 	dw $2F20, $6000, $0000, $0200, $0000	; 01 gusty glade
 	dw $6020, $88E0, $0000, $0200, $0000	; 02 ghostly grove
-	dw $9200, $9300, $0000, $0100, $0000	; 03 
+	dw $9200, $9300, $0000, $0100, $0000	; 03
 	dw $9200, $9300, $0000, $0200, $0000	; 04 web woods room
 	dw $9200, $9300, $0000, $0200, $0000	; 05 ghostly grove bonus 1
-	dw $6000, $88E0, $0000, $0200, $0000	; 06 
+	dw $6000, $88E0, $0000, $0200, $0000	; 06
 	dw $88E0, $8C80, $0000, $0200, $0000	; 07 gusty glade bonus 2
 	dw $8C80, $9060, $0000, $0200, $0000	; 08 gusty glade bonus 1/ghostly grove bonus 2
 	dw $9060, $9200, $0000, $0200, $0000	; 09 web woods bonus 2
-	dw $9300, $96E0, $0000, $0200, $0000	; 0A 
+	dw $9300, $96E0, $0000, $0200, $0000	; 0A
 	dw $FFFF
 
 ;ship_hold
@@ -6122,7 +6122,7 @@ CODE_B5C70C:
 	STZ $AC					;$B5C713   |
 	LDA $34					;$B5C715   |\
 	SEC					;$B5C717   | |
-	SBC #$0100				;$B5C718   | 
+	SBC #$0100				;$B5C718   |
 	EOR #$FFFF				;$B5C71B   |
 	INC A					;$B5C71E   |
 	AND #$FFE0				;$B5C71F   |
@@ -8166,7 +8166,7 @@ CODE_B5D644:					;	   |
 	TAY					;$B5D676   |
 	TXA					;$B5D677   |
 	CLC					;$B5D678   |
-	ADC #sizeof(sprite)			;$B5D679   |
+	ADC.w #sizeof(sprite)			;$B5D679   |
 	TAX					;$B5D67C   |
 	CPX #$02F0				;$B5D67D   |
 	BNE CODE_B5D622				;$B5D680   |
@@ -8650,7 +8650,7 @@ CODE_B5DAEB:					;	   |
 	INC $34					;$B5DB33   |
 	TYA					;$B5DB35   |
 	CLC					;$B5DB36   |
-	ADC #sizeof(sprite)			;$B5DB37   |
+	ADC.w #sizeof(sprite)			;$B5DB37   |
 	TAY					;$B5DB3A   |
 	CPY #$1074				;$B5DB3B   |
 	BEQ CODE_B5DB43				;$B5DB3E   |
@@ -8755,7 +8755,7 @@ CODE_B5DBD5:					;	   |
 	INC $36					;$B5DBFB   |
 	TYA					;$B5DBFD   |
 	CLC					;$B5DBFE   |
-	ADC #sizeof(sprite)			;$B5DBFF   |
+	ADC.w #sizeof(sprite)			;$B5DBFF   |
 	TAY					;$B5DC02   |
 	CPY #$118E				;$B5DC03   |
 	BEQ CODE_B5DC0B				;$B5DC06   |
@@ -8804,7 +8804,7 @@ CODE_B5DC3D:					;	   |
 	STA $0D8E,x				;$B5DC5B   |
 	TXA					;$B5DC5E   |
 	CLC					;$B5DC5F   |
-	ADC #sizeof(sprite)			;$B5DC60   |
+	ADC.w #sizeof(sprite)			;$B5DC60   |
 	TAX					;$B5DC63   |
 	CPX #$0178				;$B5DC64   |
 	BNE CODE_B5DC0E				;$B5DC67   |
@@ -8969,7 +8969,7 @@ CODE_B5DD93:					;	   |
 CODE_B5DD99:					;	   |
 	TXA					;$B5DD99   |
 	CLC					;$B5DD9A   |
-	ADC #sizeof(sprite)			;$B5DD9B   |
+	ADC.w #sizeof(sprite)			;$B5DD9B   |
 	TAX					;$B5DD9E   |
 	DEY					;$B5DD9F   |
 	BNE CODE_B5DD59				;$B5DDA0   |
@@ -11235,7 +11235,7 @@ CODE_B5ED61:					;	   |
 CODE_B5ED70:
 	LDX $90					;$B5ED70  \> Piracy check. Load address of anti piracy routine checksum ($A00 + $90 = $A90)
 	BMI .continue				;$B5ED72   |> If address is negative the checksum is complete. The checksum is calculated 1 byte per frame
-	LDA #<:rare_string			;$B5ED74   |\
+	LDA.w #<:rare_string			;$B5ED74   |\
 	STA $92					;$B5ED77   | | Store address of anti piracy routine at $A90
 	LDY #rare_string			;$B5ED79   | |
 	LDA [$90],y				;$B5ED7C   |/

--- a/bank_B8.asm
+++ b/bank_B8.asm
@@ -1545,7 +1545,7 @@ CODE_B88C68:					;	   |
 CODE_B88C7D:
 	TXA					;$B88C7D  \
 	CLC					;$B88C7E   |
-	ADC #sizeof(sprite)			;$B88C7F   |
+	ADC.w #sizeof(sprite)			;$B88C7F   |
 	TAX					;$B88C82   |
 	CPX #main_sprite_table_end		;$B88C83   |
 	BNE CODE_B88C68				;$B88C86   |
@@ -2816,7 +2816,7 @@ CODE_B8967D:
 	LDA #$16D8				;$B89682   |
 	STA $0591				;$B89685   |
 CODE_B89688:					;	   |
-	LDX current_sprite			;$B89688   |\ 
+	LDX current_sprite			;$B89688   |\
 	CPX active_kong_sprite			;$B8968A   | |
 	BNE kong_state_handler			;$B8968D   |/
 	LDA #$0002				;$B8968F   |
@@ -2830,7 +2830,7 @@ kong_state_handler:
 	LDA $30,x				;$B896A0  \
 	AND #$F7FF				;$B896A2   |
 	STA $30,x				;$B896A5   |
-	LDA $54,x				;$B896A7   |\ 
+	LDA $54,x				;$B896A7   |\
 	STA $8E					;$B896A9   |/
 	PHK					;$B896AB   |
 	PLB					;$B896AC   |
@@ -9700,7 +9700,7 @@ scan_for_web_platforms:
 .next_slot					;	   |
 	TXA					;$B8C9BA   |\
 	CLC					;$B8C9BB   | | move to next sprite slot
-	ADC #sizeof(sprite)			;$B8C9BC   |/
+	ADC.w #sizeof(sprite)			;$B8C9BC   |/
 	TAX					;$B8C9BF   |\
 	CPX #main_sprite_table_end		;$B8C9C0   | | check if we reached the end of the sprite table
 	BNE .scan_for_platform			;$B8C9C3   |/
@@ -9990,7 +9990,7 @@ update_object_pickup:
 	LDA #$0001				;$B8CBCA   |
 	STA $32,x				;$B8CBCD   |
 	STZ $1E,x				;$B8CBCF   |
-	LDY current_sprite			;$B8CBD1   |\ 
+	LDY current_sprite			;$B8CBD1   |\
 	LDA $0012,y				;$B8CBD3   | |
 	AND #$4000				;$B8CBD6   | | handle object distance calculation
 	BNE .facing_left			;$B8CBD9   |/ if player is facing left
@@ -12065,8 +12065,8 @@ CODE_B8D8D1:
 ;$42	divided x distance
 ;$44	divided y distance sub
 ;$46	divided y distance
-;$48	
-;$4A	
+;$48
+;$4A
 
 CODE_B8D8D5:
 	STZ $4A					;$B8D8D5  \

--- a/bank_BA.asm
+++ b/bank_BA.asm
@@ -606,7 +606,7 @@ CODE_BA94FF:					;	   |
 
 CODE_BA9502:
 	PHY					;$BA9502  \
-	LDA #$067A				;$BA9503   | 
+	LDA #$067A				;$BA9503   |
 	JSL queue_sound_effect			;$BA9506   | Play king_zing_hit sound effect
 	LDX current_sprite			;$BA950A   |
 	PHX					;$BA950C   |
@@ -821,7 +821,7 @@ DATA_BA96CA:
 	dw $0003, $FFFD
 	dw $FFFD, $FFFD
 	dw $0003, $0003
-	dw $0003, $FFFD 	
+	dw $0003, $FFFD
 	dw $FFFD, $FFFD
 	dw $0003, $0003
 	dw $0003, $FFFD
@@ -1157,7 +1157,7 @@ king_zing_stinger_sprite_code:
 	LDA $20,x				;$BA9A18   | Get current X velocity
 	EOR #$FFFF				;$BA9A1A   |
 	INC A					;$BA9A1D   | Invert and update it
-	STA $20,x				;$BA9A1E   | 
+	STA $20,x				;$BA9A1E   |
 CODE_BA9A20:					;	   |
 	STZ $26,x				;$BA9A20   | Clear target X velocity
 CODE_BA9A22:					;	   |
@@ -1414,13 +1414,13 @@ CODE_BA9C2A:					;	   |
 	LDA $32,x				;$BA9C2C   |
 	BEQ CODE_BA9C47				;$BA9C2E   |
 	LDA #$0000				;$BA9C30   |
-	PHB					;$BA9C33   | 
+	PHB					;$BA9C33   |
 	PHK					;$BA9C34   |
 	PLB					;$BA9C35   |
 	JSR.w CODE_B6F266		 	;$BA9C36   | This code was probably from B6 krow code and got moved, would have spawned egg shell pieces
 	PLB					;$BA9C39   |
 	JSL delete_sprite_handle_deallocation	;$BA9C3A   | Would have deleted egg sprite and played a barrel break sound
-	LDA #$041A				;$BA9C3E   | 
+	LDA #$041A				;$BA9C3E   |
 	JSL queue_sound_effect			;$BA9C41   |
 	BRA CODE_BA9C61				;$BA9C45  /
 
@@ -1865,7 +1865,7 @@ CODE_BA9FE2:
 	LDY #$013C				;$BAA008   |
 	JSL CODE_BB842C				;$BAA00B   |
 	LDX $0654				;$BAA00F   | get index of body sprite
-	LDA #$C000				;$BAA012   | 
+	LDA #$C000				;$BAA012   |
 	STA $1C,x				;$BAA015   | make it invisible
 	STZ $3A,x				;$BAA017   |
 	LDX $0656				;$BAA019   | get index of head sprite
@@ -2463,7 +2463,7 @@ DATA_BAA5EF:
 	db $0A, $00, $0A, $00, $0A, $00, $09, $00
 	db $09, $00, $08, $00, $08, $00, $07, $00
 	db $07, $00, $7E
-	
+
 	dw DATA_BAA590
 
 
@@ -2542,7 +2542,7 @@ DATA_BAA79A:
 	dw $0002
 	dw $FFEF, $FFF2, $0022, $001F
 	dw $FFD6, $FFD4, $0016, $001F
-	
+
 DATA_BAA7AC:
 	dw $0002
 	dw $FFD2, $FFD9, $0013, $001C
@@ -2625,7 +2625,7 @@ DATA_BAAA88:
 	dw $0100, $0000, $0100, $0000, $0909, $FC80, $1500, $004B, $FFF6
 	dw $0100, $0000, $0100, $0000, $0909, $FC80, $1500, $004B, $FFF6
 	dw $0100, $0000, $0100, $0000, $0909, $FC80, $1500, $004B, $FFF6
-	
+
 ;kleever shake offset related
 DATA_BAAABE:
 	db $02, $01
@@ -2833,7 +2833,7 @@ DATA_BAAD1E:
 
 DATA_BAAD2E:
 	dw $0018
-	
+
 ;krow 1 phase 2 falling egg data?
 DATA_BAAD30:
 	dw DATA_BAAD60
@@ -4072,8 +4072,8 @@ DATA_BAB90B:
 krool_water_drips_sprite_code:
 	LDA.l $0006A3				;$BAC0D2  \
 	BIT #$4000				;$BAC0D6   |
-	BEQ .state_handler			;$BAC0D9   | 
-	JSL delete_sprite_handle_deallocation	;$BAC0DB   | 
+	BEQ .state_handler			;$BAC0D9   |
+	JSL delete_sprite_handle_deallocation	;$BAC0DB   |
 	JML [$05A9]				;$BAC0DF  /
 
 .state_handler:
@@ -4142,7 +4142,7 @@ krool_fish_sprite_code:
 	CMP #$01C5				;$BAC147   | check if it reached 01C5
 	BCC .handle_timer			;$BAC14A   | if not, handle state transition timer
 	LDA #$01C5				;$BAC14C   | else cap it to 01C5
-	STA $0A,x				;$BAC14F   | 
+	STA $0A,x				;$BAC14F   |
 	LDA $46,x				;$BAC151   | get timer value
 	BNE .continue_bounce_state		;$BAC153   | if timer hasn't finished yet, don't transition state
 	INC $2E,x				;$BAC155   | else set fall state
@@ -4173,7 +4173,7 @@ krool_fish_sprite_code:
 	JSL queue_sound_effect			;$BAC198   | play krool water splash 1 sound
 	LDA #$065C				;$BAC19C   |
 	JSL queue_sound_effect			;$BAC19F   | play krool water splash 2 sound
-	LDX current_sprite			;$BAC1A3   | 
+	LDX current_sprite			;$BAC1A3   |
 	INC $42,x				;$BAC1A5   | increase bounce count
 .handle_timer:					;	   |
 	LDA $46,x				;$BAC1A7   | get timer value
@@ -4195,9 +4195,9 @@ krool_fish_sprite_code:
 	JSL interpolate_x_velocity_global	;$BAC1C6   | and use it as X interpolation preset
 	LDX current_sprite			;$BAC1CA   |
 	LDA $44,x				;$BAC1CC   | get Y interpolation preset
-	JSL interpolate_y_velocity_global	;$BAC1CE   | 
+	JSL interpolate_y_velocity_global	;$BAC1CE   |
 	JSL apply_position_from_velocity_global	;$BAC1D2   |
-	LDX current_sprite			;$BAC1D6   | 
+	LDX current_sprite			;$BAC1D6   |
 	RTS					;$BAC1D8  /
 
 kong_npc_sprite_code:
@@ -4650,7 +4650,7 @@ CODE_BAC958:					;	   |
 endif
 
 
-warnpc $BAD000 : padbyte $00 : pad $BAD000
+assert pc() <= $BAD000 : padbyte $00 : pad $BAD000
 
 DATA_BAD000:
 	db $0E, $00

--- a/bank_BB.asm
+++ b/bank_BB.asm
@@ -443,7 +443,7 @@ CODE_BB829A:					;	   |
 	BEQ CODE_BB82B4				;$BB829C   |
 	TXA					;$BB829E   |
 	CLC					;$BB829F   |
-	ADC #sizeof(sprite)			;$BB82A0   |
+	ADC.w #sizeof(sprite)			;$BB82A0   |
 	TAX					;$BB82A3   |
 	CPX #main_sprite_table_end		;$BB82A4   |
 	BNE CODE_BB829A				;$BB82A7   |
@@ -472,7 +472,7 @@ delete_sprite_handle_deallocation:
 #delete_sprite_no_deallocation_2:		;	   |
 	LDX current_sprite			;$BB82CD   | Get current sprite
 	STZ $00,x				;$BB82CF   | Clear sprite ID
-.return:					;	   | 
+.return:					;	   |
 	RTL					;$BB82D1  / Return
 
 #delete_sprite_no_deallocation:
@@ -497,11 +497,11 @@ delete_sprite_handle_deallocation:
 .next_slot:					;	   |
 	LDA $32					;$BB82F2   | Get type of sprite to delete
 	CMP $00,x				;$BB82F4   | Compare with current slot's type
-	BEQ .found_same_sprite_type		;$BB82F6   | If same sprite type was found 
+	BEQ .found_same_sprite_type		;$BB82F6   | If same sprite type was found
 .get_next_slot:					;	   |
 	TXA					;$BB82F8   |\
 	CLC					;$BB82F9   | |
-	ADC #sizeof(sprite)			;$BB82FA   | | Get next sprite slot
+	ADC.w #sizeof(sprite)			;$BB82FA   | | Get next sprite slot
 	TAX					;$BB82FD   |/
 	CPX #main_sprite_table_end		;$BB82FE   |\ If not end of table, go to next slot
 	BNE .next_slot				;$BB8301   |/
@@ -1146,7 +1146,7 @@ CODE_BB870B:					;	   |
 	BEQ CODE_BB8783				;$BB870F   |
 	TXA					;$BB8711   |
 	CLC					;$BB8712   |
-	ADC #sizeof(sprite)			;$BB8713   |
+	ADC.w #sizeof(sprite)			;$BB8713   |
 	TAX					;$BB8716   |
 	CPX #main_sprite_table_end		;$BB8717   |
 	BNE CODE_BB870B				;$BB871A   |
@@ -1259,7 +1259,7 @@ CODE_BB87D4:					;	   |
 	BEQ CODE_BB884C				;$BB87D8   |
 	TXA					;$BB87DA   |
 	CLC					;$BB87DB   |
-	ADC #sizeof(sprite)			;$BB87DC   |
+	ADC.w #sizeof(sprite)			;$BB87DC   |
 	TAX					;$BB87DF   |
 	CPX #main_sprite_table_end		;$BB87E0   |
 	BNE CODE_BB87D4				;$BB87E3   |
@@ -1709,7 +1709,7 @@ CODE_BB8AF6:
 	CLC					;$BB8B0E   |
 	ADC #$0081				;$BB8B0F   |
 	XBA					;$BB8B12   |
-	ORA #<:palette_data_bank		;$BB8B13   |
+	ORA.w #<:palette_data_bank		;$BB8B13   |
 	STA $0B26,x				;$BB8B16   |
 	LDA $F1					;$BB8B19   |
 	INC A					;$BB8B1B   |
@@ -1867,7 +1867,7 @@ dereference_sprite_palette:
 	TAX					;$BB8C0A   |/
 	DEC $0B74,x				;$BB8C0B   |> Decrease palette reference count
 	BMI .empty_slot				;$BB8C0E   | If reference count less than or equal to 0
-	BEQ .empty_slot				;$BB8C10   | 
+	BEQ .empty_slot				;$BB8C10   |
 	SEC					;$BB8C12   | Return slot still in use
 	RTS					;$BB8C13  /
 
@@ -2808,7 +2808,7 @@ init_sprite_render_order:			;	  \
 .next_slot					;	   |
 	STA sprite_render_table,x		;$BB9201   |\ Write sprite slot to render, increment to the next slot
 	CLC					;$BB9204   | |
-	ADC #sizeof(sprite)			;$BB9205   |/
+	ADC.w #sizeof(sprite)			;$BB9205   |/
 	INX					;$BB9208   |\ Check if all render slots have been filled
 	INX					;$BB9209   | |
 	CPX #$0032				;$BB920A   | |
@@ -6915,7 +6915,7 @@ CODE_BBB75D:					;	   |
 	BEQ CODE_BBB797				;$BBB761   |
 	TXA					;$BBB763   |
 	CLC					;$BBB764   |
-	ADC #sizeof(sprite)			;$BBB765   |
+	ADC.w #sizeof(sprite)			;$BBB765   |
 	TAX					;$BBB768   |
 	CPX #main_sprite_table_end		;$BBB769   |
 	BNE CODE_BBB75D				;$BBB76C   |
@@ -8190,7 +8190,7 @@ DATA_BBC070:
 CODE_BBC07E:
 	LDA $0551				;$BBC07E  \
 	STA $26					;$BBC081   |
-	LDA #<:level_settings_data_bank		;$BBC083   |
+	LDA.w #<:level_settings_data_bank	;$BBC083   |
 	STA $28					;$BBC086   |
 	BRA CODE_BBC098				;$BBC088  /
 
@@ -8784,7 +8784,7 @@ calculate_checksum:				;	  \
 	STA .additive_checksum			;$BBC591   | |
 	INY					;$BBC593   | | DKC2 subtracts the header size from the loop, but this
 	INY					;$BBC594   | | is not actually correct.  However, the last 6 bytes are
-	CPY #sizeof(save_file)-6		;$BBC595   | | unused, so this doesn't cause issue.
+	CPY.w #sizeof(save_file)-6		;$BBC595   | | unused, so this doesn't cause issue.
 	BNE .calculate_additive			;$BBC598   |/
 	LDY.w #save_file.contents		;$BBC59A   | Load the an offset past the sram header
 .calculate_xor					;	   |
@@ -8793,7 +8793,7 @@ calculate_checksum:				;	  \
 	STA .xor_checksum			;$BBC5A1   | |
 	INY					;$BBC5A3   | |
 	INY					;$BBC5A4   | |
-	CPY #sizeof(save_file)-6		;$BBC5A5   | | The same header skip bug is present here
+	CPY.w #sizeof(save_file)-6		;$BBC5A5   | | The same header skip bug is present here
 	BNE .calculate_xor			;$BBC5A8   |/
 	RTS					;$BBC5AA  /
 
@@ -8818,7 +8818,7 @@ CODE_BBC5CC:
 	TAX					;$BBC5D0   |
 	LDA.l DATA_BBC5EE,x			;$BBC5D1   |
 	STA $32					;$BBC5D5   |
-	LDA #<:sram_base			;$BBC5D7   |
+	LDA.w #<:sram_base			;$BBC5D7   |
 	STA $34					;$BBC5DA   |
 	%pea_use_dbr(sram_file_buffer)		;$BBC5DC   |
 	PLB					;$BBC5DF   |
@@ -8842,7 +8842,7 @@ CODE_BBC5F4:
 	JSL CODE_BB819F				;$BBC5F4  \
 	LDA #sram_file_buffer			;$BBC5F8   |
 	STA $26					;$BBC5FB   |
-	LDA #<:sram_file_buffer			;$BBC5FD   |
+	LDA.w #<:sram_file_buffer		;$BBC5FD   |
 	STA $28					;$BBC600   |
 	SEP #$20				;$BBC602   |
 	LDA $060D				;$BBC604   |
@@ -9216,7 +9216,7 @@ CODE_BBC8EF:					;	   |
 	RTS					;$BBC8FE  /
 
 
-warnpc $BBE800 : padbyte $00 : pad $BBE800
+assert pc() <= $BBE800 : padbyte $00 : pad $BBE800
 
 %mirror(DATA_FBE800)
 	dw DATA_FF2A08				;0000 4 chest spawner (not placed)
@@ -9379,7 +9379,7 @@ warnpc $BBE800 : padbyte $00 : pad $BBE800
 	dw DATA_FF35AC				;013A Cannon (not placed)
 	dw DATA_FF35CE				;013C Cannon
 	dw DATA_FF3648				;013E Animal Barrel (Squitter)
-	dw DATA_FF366A				;0140 Animal Barrel (Rattly) 
+	dw DATA_FF366A				;0140 Animal Barrel (Rattly)
 	dw DATA_FF368C				;0142 Animal Barrel (Squawks)
 	dw DATA_FF36AE				;0144 Animal Barrel (Rambi)
 	dw DATA_FF36D0				;0146 Animal Barrel (Enguarde)

--- a/bank_BC.asm
+++ b/bank_BC.asm
@@ -8763,7 +8763,7 @@ DATA_BCEDC8:
 	dw $FFFB, $FFE4, $000D, $001B, $00D8, $01BF
 
 
-warnpc $BCFA00 : padbyte $00 : pad $BCFA00
+assert pc() <= $BCFA00 : padbyte $00 : pad $BCFA00
 
 ;special hitboxes
 DATA_BCFA00:
@@ -8781,7 +8781,7 @@ DATA_BCFA00:
 	dw $FFE2, $FFE8, $001F, $0023		;0B kleever range?
 	dw $FFEE, $FFF1, $001B, $0014		;0C rattly auto stomp range
 	dw $0008, $FFF8, $0024, $0010		;0D kutlass attack range
-	dw $FFD0, $FFA8, $0050, $0060		;0E 
+	dw $FFD0, $FFA8, $0050, $0060		;0E
 
 CODE_BCFA78:
 	STZ $09A7				;$BCFA78  \
@@ -9296,7 +9296,7 @@ CODE_BCFE0A:
 .next_sprite					;	   |
 	LDA $6A					;$BCFE28   |> Get sprite to check collision against
 	SEC					;$BCFE2A   |\
-	SBC #sizeof(sprite)			;$BCFE2B   | | Move to previous slot
+	SBC.w #sizeof(sprite)			;$BCFE2B   | | Move to previous slot
 	STA $6A					;$BCFE2E   |/
 	CMP #$0E40				;$BCFE30   |\ Check if dixie slot
 	BEQ CODE_BCFE07				;$BCFE33   |/ If on dixie slot, no more sprites need to be checked because the rest are kongs
@@ -9467,7 +9467,7 @@ CODE_BCFF38:					;	   |
 	LDA $6A					;$BCFF3B   |
 	CMP #aux_sprite_table+1			;$BCFF3D   |\
 	BCC CODE_BCFF6E				;$BCFF40   |/ This might be a bug because it will continue to process aux as if it can have collision
-	SBC #sizeof(sprite)			;$BCFF42   |
+	SBC.w #sizeof(sprite)			;$BCFF42   |
 	STA $6A					;$BCFF45   |
 	CMP current_sprite			;$BCFF47   |
 	BEQ .next_sprite			;$BCFF49   |

--- a/bank_BE.asm
+++ b/bank_BE.asm
@@ -385,8 +385,8 @@ CODE_BEBACA:
 	TSB $0902				;$BEBAE8   | set the corresponding kong letter bit
 	LDA $0902				;$BEBAEB   | get collected kong letters
 	INC A					;$BEBAEE   |
-	AND #$000F				;$BEBAEF   |	
-	STA $52,x				;$BEBAF2   |	
+	AND #$000F				;$BEBAEF   |
+	STA $52,x				;$BEBAF2   |
 	BNE CODE_BEBAFD				;$BEBAF4   | if all the kong letters arent collected yet dont give an extra life
 	LDA #$0001				;$BEBAF6   | number of lives to give
 	JSL CODE_BEC64C				;$BEBAF9   | give extra lives
@@ -427,14 +427,14 @@ CODE_BEBB2A:
 	ASL A					;$BEBB37   |
 	ASL A					;$BEBB38   |
 	ASL A					;$BEBB39   |
-	LDX.l #DATA_C02401>>16|$0800		;$BEBB3A   |	
+	LDX.w #DATA_C02401>>16|$0800		;$BEBB3A   |
 	LDY #DATA_C02401			;$BEBB3D   | kong letters top tiledata
 	PHA					;$BEBB40   |
 	JSR CODE_BEBD5C				;$BEBB41   |
 	PLA					;$BEBB44   |
 	BCS CODE_BEBB5E				;$BEBB45   |
 	ADC #$0100				;$BEBB47   |
-	LDX.l #DATA_C02501>>16|$0800		;$BEBB4A   |
+	LDX.w #DATA_C02501>>16|$0800		;$BEBB4A   |
 	LDY #DATA_C02501			;$BEBB4D   | kong letters bottom tiledata
 	JSR CODE_BEBD5C				;$BEBB50   |
 	BCC CODE_BEBB61				;$BEBB53   |
@@ -1921,13 +1921,13 @@ set_sprite_target_hud_position:
 	LDA #$0000				;$BEC5D7   | Else sprite is offscreen, load cap value
 CODE_BEC5DA:					;	   |
 	CMP #$0100				;$BEC5DA   | Check if sprite X is at right border of the camera
-	BCC CODE_BEC5E2				;$BEC5DD   | 
+	BCC CODE_BEC5E2				;$BEC5DD   |
 	LDA #$00FF				;$BEC5DF   | Else cap it to right border
 CODE_BEC5E2:					;	   |
 	STA $06,x				;$BEC5E2   | Update X position
 	LDA $0A,x				;$BEC5E4   |
 	SEC					;$BEC5E6   | Repeat process for Y position
-	SBC $17C0				;$BEC5E7   | 
+	SBC $17C0				;$BEC5E7   |
 	BCS CODE_BEC5EF				;$BEC5EA   |
 	LDA #$0000				;$BEC5EC   |
 CODE_BEC5EF:					;	   |
@@ -3026,7 +3026,7 @@ CODE_BECDDF:					;	   |
 
 gate_barrel_sprite_code:
 	JSR CODE_BEB82A				;$BECDE2  \
-	
+
 DATA_BECDE5:
 	dw CODE_BECDEB
 	dw CODE_BECE07
@@ -4281,14 +4281,14 @@ set_klank_race_kart_velocity:
 
 .set_velocities
 	INY					;$BED776  \
-	INY					;$BED777   | increase counter by 4 
+	INY					;$BED777   | increase counter by 4
 	INY					;$BED778   |
 	INY					;$BED779   |
 	LDA [$32],y				;$BED77A   | read 3rd word (inital target X speed to apply)
 	STA $2A,x				;$BED77C   | set kart's initial target X speed
 	LDA $0A,x				;$BED77E   | get Y position
-	STA $1C,x				;$BED780   | 
-	STA $20,x				;$BED782   | 
+	STA $1C,x				;$BED780   |
+	STA $20,x				;$BED782   |
 	STZ $2C,x				;$BED784   | clear initial current X speed
 	TYA					;$BED786   |
 	CLC					;$BED787   |
@@ -5853,7 +5853,7 @@ haunted_hall_timer_handler_code:		;	  \
 	BIT #$0004				;$BEE2DC   |
 	BEQ .handle_state			;$BEE2DF   | If time isnt stopped, handle state logic
 	LDY current_sprite			;$BEE2E1   | Else get handler sprite
-	LDA $002E,y				;$BEE2E3   | 
+	LDA $002E,y				;$BEE2E3   |
 	AND #$00FF				;$BEE2E6   | Get current state low byte
 	CMP #$0006				;$BEE2E9   |
 	BEQ .handle_state			;$BEE2EC   | If in state 6, handle state logic
@@ -5998,7 +5998,7 @@ haunted_hall_timer_handler_code:		;	  \
 	LDY $0D5A				;$BEE3D2   | Get index of kackle sprite
 	LDA $002E,y				;$BEE3D5   |
 	AND #$00FF				;$BEE3D8   | Get low byte of kackle state
-	CMP #$0006				;$BEE3DB   | 
+	CMP #$0006				;$BEE3DB   |
 	BEQ ..return				;$BEE3DE   | If in state 6, return
 	LDA #$0001				;$BEE3E0   |
 	STA $2E,x				;$BEE3E3   | Else set handler to state 1
@@ -6427,7 +6427,7 @@ race_handler_sprite_code:
 
 
 .init_state
-	LDA $0044,y				;$BEE6FF  \  
+	LDA $0044,y				;$BEE6FF  \
 	ORA #$0080				;$BEE702   |
 	STA $0D5C				;$BEE705   | initialize player's race placement
 	JSR spawn_and_setup_klank_kart		;$BEE708   | spawn the first klank's kart, setup speed and trigger data
@@ -6449,7 +6449,7 @@ race_handler_sprite_code:
 	STY $4E,x				;$BEE728   | store index to traffic light in the handler
 	INC $2E,x				;$BEE72A   | go to state 2 to wait for green light
 	LDA #$8000				;$BEE72C   |
-	TSB $0923				;$BEE72F   | 
+	TSB $0923				;$BEE72F   |
 ..return					;	   |
 	JML [$05A9]				;$BEE732  /  Done processing sprite
 
@@ -6469,7 +6469,7 @@ race_handler_sprite_code:
 	LDA $17BA				;$BEE74A   | get camera X position
 	CMP #$5C80				;$BEE74D   | check if we're at or passed the spot the race should end
 	BCC ..continue_handling_race		;$BEE750   | if not, continue handling it
-	LDA #$8000				;$BEE752   | 
+	LDA #$8000				;$BEE752   |
 	TSB $0923				;$BEE755   |
 	JSR update_race_flag			;$BEE758   | update the flag
 	LDX current_sprite			;$BEE75B   | get handler sprite
@@ -6490,7 +6490,7 @@ race_handler_sprite_code:
 	JSR update_race_flag			;$BEE77B   | else update it (called every frame until player's placement changes)
 	BCS ..skip_flag_update			;$BEE77E   | if it hasn't spawned yet, don't play rank-up sound
 	%lda_sound(7, coaster_race_rank_up)	;$BEE780   | else play it
-	JSL queue_sound_effect			;$BEE783   | 
+	JSL queue_sound_effect			;$BEE783   |
 ..skip_flag_update				;	   |
 	LDA $0923				;$BEE787   |
 	AND #$0003				;$BEE78A   |
@@ -6498,7 +6498,7 @@ race_handler_sprite_code:
 	BNE ..return				;$BEE790   |
 	JSR spawn_and_setup_klank_kart		;$BEE792   | spawn next klank kart and update speed and trigger data
 	BCS ..return				;$BEE795   | if kart is not able to spawn yet, return
-	LDA #$0001				;$BEE797   | 
+	LDA #$0001				;$BEE797   |
 	TRB $0923				;$BEE79A   | else clear bit 0
 ..return					;	   |
 	JML [$05A9]				;$BEE79D  /  Done processing sprite
@@ -6543,7 +6543,7 @@ race_handler_sprite_code:
 	RTS					;$BEE7EC  /  return
 
 update_race_flag:
-	SEC					;$BEE7ED  \  
+	SEC					;$BEE7ED  \
 	LDA $092E				;$BEE7EE   | get number off firework sprites onscreen
 	AND #$00FF				;$BEE7F1   |
 	BNE .return				;$BEE7F4   | if there are any, don't update flag and return
@@ -6570,7 +6570,7 @@ update_race_flag:
 	LDA $0D5C				;$BEE81E   |
 	AND #$007F				;$BEE821   |
 	STA $4C,x				;$BEE824   | update mirror of player's race placement
-.return						;	   | 
+.return						;	   |
 	RTS					;$BEE826  /  return
 
 spawn_and_setup_klank_kart:
@@ -6585,15 +6585,15 @@ spawn_and_setup_klank_kart:
 	ASL A					;$BEE835   |
 	ADC #klank_race_kart_data_table		;$BEE836   | add base address of klank kart race data table
 	STA $06,x				;$BEE839   |
-	STA $32					;$BEE83B   | 
+	STA $32					;$BEE83B   |
 	LDA.w #<:klank_race_data_bank		;$BEE83D   | get the bank of the table
 	STA $34					;$BEE840   |
 	LDA [$32]				;$BEE842   | get spawn location data
-	STA $32					;$BEE844   | 
+	STA $32					;$BEE844   |
 	LDY #$0000				;$BEE846   | initialize iteration counter
 	LDA $42,x				;$BEE849   | get race timer
 	SEC					;$BEE84B   |
-	BEQ .check_spawn_time_limit		;$BEE84C   | if race hasn't started yet, 
+	BEQ .check_spawn_time_limit		;$BEE84C   | if race hasn't started yet,
 .check_valid_spawn_position			;	   |
 	LDA [$32],y				;$BEE84E   | get kart X spawn position
 	BMI .return				;$BEE850   | if negative, there are no more possible spawn positions, return
@@ -6605,10 +6605,10 @@ spawn_and_setup_klank_kart:
 	CMP #$0100				;$BEE85D   | else check if its at the edge of the screen
 	BCS .check_spawn_time_limit		;$BEE860   | if yes, position is valid, check if kart can spawn
 ..get_next_position				;	   |
-	TYA					;$BEE862   | 
+	TYA					;$BEE862   |
 	ADC #$0006				;$BEE863   | else offset counter by 6 to get to next spawn position
 	TAY					;$BEE866   |
-	BRA .check_valid_spawn_position		;$BEE867  /  
+	BRA .check_valid_spawn_position		;$BEE867  /
 
 .return
 	SEC					;$BEE869  \ tell caller we failed to spawn the kart
@@ -6618,7 +6618,7 @@ spawn_and_setup_klank_kart:
 	INY					;$BEE86B  \
 	INY					;$BEE86C   |
 	INY					;$BEE86D   | increase counter by 4 to get the last word
-	INY					;$BEE86E   | 
+	INY					;$BEE86E   |
 	LDA $42,x				;$BEE86F   | get race timer
 	CMP [$32],y				;$BEE871   | compare with the klank's spawn time limit
 	BCC ..spawn_kart			;$BEE873   | if below the limit, spawn the kart
@@ -6632,7 +6632,7 @@ spawn_and_setup_klank_kart:
 	DEY					;$BEE87B   | decrease counter to get back to first word
 	DEY					;$BEE87C   |
 	PHY					;$BEE87D   | preserve the counter
-	LDA $32					;$BEE87E   | 
+	LDA $32					;$BEE87E   |
 	PHA					;$BEE880   | preserve address of klank kart spawn data
 	LDY $36,x				;$BEE881   | get address of kart init script
 	JSL CODE_BB8432				;$BEE883   | spawn the klank's kart
@@ -6693,16 +6693,16 @@ racing_flag_sprite_code:
 ;sub states handled by $2F,x
 ;values above 4 are for screech's sprint
 .traffic_light_sub_state_table
-	dw .init_if_rickety_state  	
-	dw .lower_down_state 	
-	dw .start_countdown_if_rickety_state	
-	dw .wait_state 	
-	dw .rise_up_state 	
-	dw .init_if_screech_state	
-	dw .lower_down_state 	
-	dw .start_countdown_if_screech_state 	
-	dw .wait_state 	
-	dw .rise_up_state 	
+	dw .init_if_rickety_state
+	dw .lower_down_state
+	dw .start_countdown_if_rickety_state
+	dw .wait_state
+	dw .rise_up_state
+	dw .init_if_screech_state
+	dw .lower_down_state
+	dw .start_countdown_if_screech_state
+	dw .wait_state
+	dw .rise_up_state
 
 
 .init_if_screech_state
@@ -6724,14 +6724,14 @@ racing_flag_sprite_code:
 	BMI ..update_y_pos			;$BEE909   | if position still negative, update it and return
 	CMP #$0040				;$BEE90B   | check if we've reached desired Y position
 	BCC ..update_y_pos			;$BEE90E   | if not, continue updating it and return
-	LDA #$0040				;$BEE910   | 
+	LDA #$0040				;$BEE910   |
 	INC $2F,x				;$BEE913   | else set next sub state (start countdown)
 ..update_y_pos					;	   |
 	STA $0A,x				;$BEE915   | update Y position
 	JML [$05A9]				;$BEE917  /  Done processing sprite
 
 .start_countdown_if_rickety_state
-	LDA $0D5E				;$BEE91A  \  get index of skull kart player is riding 
+	LDA $0D5E				;$BEE91A  \  get index of skull kart player is riding
 	BEQ .return				;$BEE91D   | if not riding one yet, return
 .start_countdown_if_screech_state		;	   |
 	LDA $0042,y				;$BEE91F   |
@@ -6767,7 +6767,7 @@ racing_flag_sprite_code:
 	STA $004E,y				;$BEE95B   | else clear index to traffic light in the handler sprite
 ..not_rickety:					;	   |
 	LDA #$0003				;$BEE95E   |
-	TRB $0A36				;$BEE961   | disable timestop 
+	TRB $0A36				;$BEE961   | disable timestop
 	INC $2F,x				;$BEE964   | set next sub state (rise up)
 	%lda_sound(6, starting_light_2)		;$BEE966   | play green light sound effect
 	JSL queue_sound_effect			;$BEE969   |
@@ -6819,19 +6819,19 @@ racing_flag_sprite_code:
 
 .init_state
 	TYX					;$BEE9B6  \  put flag sprite in X
-	LDA $44,x				;$BEE9B7   | get despawn timer 
+	LDA $44,x				;$BEE9B7   | get despawn timer
 	STA $42,x				;$BEE9B9   | store a mirror of it
 	INC $2F,x				;$BEE9BB   | set next sub state
-.sub_state_1:					;	   | 
+.sub_state_1:					;	   |
 	TYX					;$BEE9BD   | put flag sprite in X
-	LDA #$C000				;$BEE9BE   | 
-	STA $001C,y				;$BEE9C1   | make flag invisible 
+	LDA #$C000				;$BEE9BE   |
+	STA $001C,y				;$BEE9C1   | make flag invisible
 	SEP #$20				;$BEE9C4   | 8-bit A
 	STZ $0D5D				;$BEE9C6   | clear high byte of player's race placement
 	REP #$20				;$BEE9C9   | 16-bit A
 	DEC $42,x				;$BEE9CB   | decrease despawn timer
 	BMI ..despawn_flag			;$BEE9CD   | if negative, despawn the flag
-	LDA $42,x				;$BEE9CF   | 
+	LDA $42,x				;$BEE9CF   |
 	AND #$001F				;$BEE9D1   | else use bits of timer to check if visibility should be enabled
 	CMP #$0014				;$BEE9D4   |
 	BCC .enable_visibility_state		;$BEE9D7   | if yes make the flag visible
@@ -6896,7 +6896,7 @@ racing_flag_sprite_code:
 ..count_down_timer				;	   |
 	DEC $42,x				;$BEEA55   | else decrease despawn timer
 	BMI ..despawn_flag			;$BEEA57   | if negative despawn the flag
-	LDA $42,x				;$BEEA59   | 
+	LDA $42,x				;$BEEA59   |
 	AND #$001F				;$BEEA5B   | else use bits of timer to check if visibility should be enabled
 	CMP #$0014				;$BEEA5E   |
 	BCC .enable_visibility_state		;$BEEA61   |

--- a/bank_C0.asm
+++ b/bank_C0.asm
@@ -657,7 +657,7 @@ intro_sparkle_graphics:
 ;$C00DA1
 DATA_C00DA1:
 	incbin "data/misc_graphics/hook_tiledata.bin"
-	
+
 ;$C01021
 DATA_C01021:
 	incbin "data/misc_graphics/cannon_ball_fragment_tiledata.bin"
@@ -684,11 +684,11 @@ DATA_C02321:
 
 ;$C02401
 DATA_C02401:
-	incbin "data/misc_graphics/kong_letters_tiledata.bin":0000-0100
+	incbin "data/misc_graphics/kong_letters_tiledata.bin":$0000..$0100
 
 ;$C02501
 DATA_C02501:
-	incbin "data/misc_graphics/kong_letters_tiledata.bin":0100-0200
+	incbin "data/misc_graphics/kong_letters_tiledata.bin":$0100..$0200
 
 ;$C02601 (sprite graphic)
 SPRITE_GRAPHIC_02C4:

--- a/bank_C1-ED.asm
+++ b/bank_C1-ED.asm
@@ -13400,11 +13400,11 @@ lava_fall_layer_3_8x8_tilemap:
 
 ;$E9A745
 DATA_E9A745:
-	incbin "data/backgrounds/8x8_tilemaps/castle_crush_floor_layer_3_tilemap.bin":0000-00C0
+	incbin "data/backgrounds/8x8_tilemaps/castle_crush_floor_layer_3_tilemap.bin":$0000..$00C0
 
 ;$E9A805
 DATA_E9A805:
-	incbin "data/backgrounds/8x8_tilemaps/castle_crush_floor_layer_3_tilemap.bin":00C0-01C0
+	incbin "data/backgrounds/8x8_tilemaps/castle_crush_floor_layer_3_tilemap.bin":$00C0..$01C0
 
 ;$E9A905
 DATA_E9A905:
@@ -13547,7 +13547,7 @@ DATA_EC7CF0:
 ;$EC83A0	compressed
 DATA_EC83A0:
 	incbin "data/screens/graphics/file_select_bg_tiledata.bin"
-	
+
 	incbin "data/screens/graphics/video_game_hero_screen_unused_tiledata.bin"
 	incbin "data/screens/8x8_tilemaps/video_game_hero_screen_unused_8x8_tilemap.bin"
 

--- a/bank_F9.asm
+++ b/bank_F9.asm
@@ -11969,7 +11969,7 @@ DATA_F98FAB:
 	db !animation_command_80, $00
 
 
-warnpc $F99400 : padbyte $00 : pad $F99400
+assert pc() <= $F99400 : padbyte $00 : pad $F99400
 
 ;$F99400
 DATA_F99400:

--- a/bank_FA.asm
+++ b/bank_FA.asm
@@ -12,19 +12,19 @@ DATA_FA0660:
 
 ;$FA0A60
 DATA_FA0A60:
-	incbin "data/misc_graphics/ship_hold_window_tiledata.bin":0000-0040
+	incbin "data/misc_graphics/ship_hold_window_tiledata.bin":$0000..$0040
 
 ;$FA0AA0
 DATA_FA0AA0:
-	incbin "data/misc_graphics/ship_hold_window_tiledata.bin":0040-0060
+	incbin "data/misc_graphics/ship_hold_window_tiledata.bin":$0040..$0060
 
 ;$FA0AC0
 DATA_FA0AC0:
-	incbin "data/misc_graphics/ship_hold_window_tiledata.bin":0060-0080
+	incbin "data/misc_graphics/ship_hold_window_tiledata.bin":$0060..$0080
 
 ;$FA0AE0
 DATA_FA0AE0:
-	incbin "data/misc_graphics/ship_hold_window_tiledata.bin":0080-00C0
+	incbin "data/misc_graphics/ship_hold_window_tiledata.bin":$0080..$00C0
 
 ;$FA0B20
 DATA_FA0B20:

--- a/bank_FB.asm
+++ b/bank_FB.asm
@@ -1,14 +1,14 @@
 ;$FB0000
 DATA_FB0000:
-	incbin "data/misc_graphics/file_select_coins_tiledata.bin":0000-0180
+	incbin "data/misc_graphics/file_select_coins_tiledata.bin":$0000..$0180
 
 ;$FB0180
 DATA_FB0180:
-	incbin "data/misc_graphics/file_select_coins_tiledata.bin":0180-0400
+	incbin "data/misc_graphics/file_select_coins_tiledata.bin":$0180..$0400
 
 ;$FB0400
 DATA_FB0400:
-	incbin "data/misc_graphics/file_select_coins_tiledata.bin":0400-0800
+	incbin "data/misc_graphics/file_select_coins_tiledata.bin":$0400..$0800
 
 ;$FB0800
 DATA_FB0800:

--- a/bank_FC.asm
+++ b/bank_FC.asm
@@ -4,175 +4,175 @@ DATA_FC0000:
 
 ;$FC0660
 DATA_FC0660:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0000-0040
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0000..$0040
 ;$FC06A0
 DATA_FC06A0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0040-0080
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0040..$0080
 ;$FC06E0
 DATA_FC06E0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0080-00C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0080..$00C0
 ;$FC0720
 DATA_FC0720:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":00C0-0100
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$00C0..$0100
 ;$FC0760
 DATA_FC0760:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0100-0140
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0100..$0140
 ;$FC07A0
 DATA_FC07A0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0140-0180
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0140..$0180
 ;$FC07E0
 DATA_FC07E0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0180-01C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0180..$01C0
 ;$FC0820
 DATA_FC0820:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":01C0-0200
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$01C0..$0200
 ;$FC0860
 DATA_FC0860:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0200-0240
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0200..$0240
 ;$FC08A0
 DATA_FC08A0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0240-0280
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0240..$0280
 ;$FC08E0
 DATA_FC08E0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0280-02C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0280..$02C0
 ;$FC0920
 DATA_FC0920:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":02C0-0300
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$02C0..$0300
 ;$FC0960
 DATA_FC0960:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0300-0340
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0300..$0340
 ;$FC09A0
 DATA_FC09A0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0340-0380
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0340..$0380
 ;$FC09E0
 DATA_FC09E0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0380-03C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0380..$03C0
 ;$FC0A20
 DATA_FC0A20:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":03C0-0400
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$03C0..$0400
 ;$FC0A60
 DATA_FC0A60:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0400-0440
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0400..$0440
 ;$FC0AA0
 DATA_FC0AA0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0440-0480
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0440..$0480
 ;$FC0AE0
 DATA_FC0AE0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0480-04C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0480..$04C0
 ;$FC0B20
 DATA_FC0B20:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":04C0-0500
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$04C0..$0500
 ;$FC0B60
 DATA_FC0B60:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0500-0540
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0500..$0540
 ;$FC0BA0
 DATA_FC0BA0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0540-0580
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0540..$0580
 ;$FC0BE0
 DATA_FC0BE0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0580-05C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0580..$05C0
 ;$FC0C20
 DATA_FC0C20:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":05C0-0600
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$05C0..$0600
 ;$FC0C60
 DATA_FC0C60:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0600-0640
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0600..$0640
 ;$FC0CA0
 DATA_FC0CA0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0640-0680
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0640..$0680
 ;$FC0CE0
 DATA_FC0CE0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0680-06C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0680..$06C0
 ;$FC0D20
 DATA_FC0D20:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":06C0-0700
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$06C0..$0700
 ;$FC0D60
 DATA_FC0D60:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0700-0740
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0700..$0740
 ;$FC0DA0
 DATA_FC0DA0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0740-0780
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0740..$0780
 ;$FC0DE0
 DATA_FC0DE0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0780-07C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0780..$07C0
 ;$FC0E20
 DATA_FC0E20:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":07C0-0800
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$07C0..$0800
 ;$FC0E60
 DATA_FC0E60:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0800-0840
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0800..$0840
 ;$FC0EA0
 DATA_FC0EA0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0840-0880
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0840..$0880
 ;$FC0EE0
 DATA_FC0EE0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0880-08C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0880..$08C0
 ;$FC0F20
 DATA_FC0F20:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":08C0-0900
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$08C0..$0900
 ;$FC0F60
 DATA_FC0F60:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0900-0940
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0900..$0940
 ;$FC0FA0
 DATA_FC0FA0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0940-0980
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0940..$0980
 ;$FC0FE0
 DATA_FC0FE0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0980-09C0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0980..$09C0
 ;$FC1020
 DATA_FC1020:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":09C0-0A00
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$09C0..$0A00
 ;$FC1060
 DATA_FC1060:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0A00-0A40
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0A00..$0A40
 ;$FC10A0
 DATA_FC10A0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0A40-0A80
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0A40..$0A80
 ;$FC10E0
 DATA_FC10E0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0A80-0AC0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0A80..$0AC0
 ;$FC1120
 DATA_FC1120:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0AC0-0B00
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0AC0..$0B00
 ;$FC1160
 DATA_FC1160:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0B00-0B40
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0B00..$0B40
 ;$FC11A0
 DATA_FC11A0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0B40-0B80
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0B40..$0B80
 ;$FC11E0
 DATA_FC11E0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0B80-0BC0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0B80..$0BC0
 ;$FC1220
 DATA_FC1220:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0BC0-0C00
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0BC0..$0C00
 ;$FC1260
 DATA_FC1260:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0C00-0C40
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0C00..$0C40
 ;$FC12A0
 DATA_FC12A0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0C40-0C80
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0C40..$0C80
 ;$FC12E0
 DATA_FC12E0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0C80-0CC0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0C80..$0CC0
 ;$FC1320
 DATA_FC1320:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0CC0-0D00
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0CC0..$0D00
 ;$FC1360
 DATA_FC1360:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0D00-0D40
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0D00..$0D40
 ;$FC13A0
 DATA_FC13A0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0D40-0D80
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0D40..$0D80
 ;$FC13E0
 DATA_FC13E0:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0D80-0DC0
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0D80..$0DC0
 ;$FC1420
 DATA_FC1420:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0DC0-0E00
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0DC0..$0E00
 ;$FC1460
 DATA_FC1460:
-	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":0E00-0E40
+	incbin "data/misc_graphics/world_map_8x16_text_tiledata.bin":$0E00..$0E40
 
 ;$FC14A0
 DATA_FC14A0:

--- a/ram.asm
+++ b/ram.asm
@@ -120,8 +120,6 @@ player_skipped_demo = $099B
 current_held_sprite = $0D7A
 
 aux_sprite_table = $0D84
-main_sprite_table = $0DE2
-main_sprite_table_end = $0DE2+(sizeof(sprite)*24)
 
 sprite_render_table = $16FE
 sprite_render_table_end = $16FE+$30

--- a/structs.asm
+++ b/structs.asm
@@ -54,6 +54,11 @@ struct sprite $0000
 	.unknown_5C:		skip 2	;5C
 endstruct
 
+; FIXME: these are here because they need to be after `struct sprite`,
+; but other parts of structs.asm need to be after ram.asm
+main_sprite_table = $0DE2
+main_sprite_table_end = $0DE2+(sizeof(sprite)*24)
+
 struct oam oam_table
 	.position:
 	.x:             skip 1


### PR DESCRIPTION
Fixes compatibility issues with asar 2.0, mostly changes to how the size-guesser handles `sizeof` and `<:`, so i added a bunch of manual width specifiers.

note that `assert pc()` and the new incbin syntax both require asar 1.90. I hope that's okay, given that it's been out for over a year.